### PR TITLE
Add depreation warning for gym_robotics package

### DIFF
--- a/gym_robotics/__init__.py
+++ b/gym_robotics/__init__.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from gym.envs.registration import register
 
 from gym_robotics.core import GoalEnv
@@ -8,6 +10,14 @@ __version__ = _version.get_versions()["version"]
 
 
 def register_robotics_envs():
+
+    # gym_robotics package deprecated in favor of gymnasium_robotics
+    warn(
+        "The package name gym_robotics has been deprecated in favor of gymnasium_robotics. Please uninstall gym_robotics and install gymnasium_robotics with `pip install gymnasium_robotics`. Future releases will be maintained under the new package name gymnasium_robotics.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     def _merge(a, b):
         a.update(b)
         return a


### PR DESCRIPTION
# Description

Add deprecation warning to install `gymnasium_robotics` instead of `gym_robotics`. `gymnasium_robotics` will be the new name of the package since the dependency on `gym` will be migrated to `gymnasium`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
