### PR TITLE
DOC typo fix

### DIFF
--- a/docs/envs/hand_touch/index.md
+++ b/docs/envs/hand_touch/index.md
@@ -14,7 +14,7 @@ These environments are instanceated by adding the following strings to the Hand 
 ```python
 import gymnasium as gym
 
-env = gym.make('HandManipulateEgg_BooleanTouchSensor-v1')
+env = gym.make('HandManipulateEgg_BooleanTouchSensors-v1')
 ```
 
 ```{raw} html


### PR DESCRIPTION
Just a typo fix

```
import gymnasium
>>> env = gymnasium.make('HandManipulateEgg_BooleanTouchSensor-v1') #does not work
>>> env = gymnasium.make('HandManipulateEgg_BooleanTouchSensors-v1') #works
```