### PR TITLE
Update to refactored mujoco renderer in Gymnasium v0.27.0

### DIFF
--- a/gymnasium_robotics/envs/robot_env.py
+++ b/gymnasium_robotics/envs/robot_env.py
@@ -2,7 +2,6 @@ import copy
 import os
 from typing import Optional, Union
 
-import gymnasium as gym
 import numpy as np
 from gymnasium import error, logger, spaces
 
@@ -202,12 +201,6 @@ class BaseRobotEnv(GoalEnv):
         """
         pass
 
-    def _viewer_setup(self):
-        """Initial configuration of the viewer. Can be used to set the camera position,
-        for example.
-        """
-        pass
-
     def _render_callback(self):
         """A custom callback that is called before rendering. Can be used
         to implement custom visualizations.
@@ -222,7 +215,7 @@ class BaseRobotEnv(GoalEnv):
 
 
 class MujocoRobotEnv(BaseRobotEnv):
-    def __init__(self, **kwargs):
+    def __init__(self, default_camera_config: Optional[dict] = None, **kwargs):
         if MUJOCO_IMPORT_ERROR is not None:
             raise error.DependencyNotInstalled(
                 f"{MUJOCO_IMPORT_ERROR}. (HINT: you need to install mujoco)"
@@ -232,6 +225,12 @@ class MujocoRobotEnv(BaseRobotEnv):
         self._utils = mujoco_utils
 
         super().__init__(**kwargs)
+
+        from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer
+
+        self.mujoco_renderer = MujocoRenderer(
+            self.model, self.data, default_camera_config
+        )
 
     def _initialize_simulation(self):
         self.model = self._mujoco.MjModel.from_xml_path(self.fullpath)
@@ -258,35 +257,11 @@ class MujocoRobotEnv(BaseRobotEnv):
 
     def render(self):
         self._render_callback()
-        if self.render_mode == "rgb_array":
-            self._get_viewer(self.render_mode).render()
-            data = self._get_viewer(self.render_mode).read_pixels(depth=False)
-            # original image is upside-down, so flip it
-            return data[::-1, :, :]
-        elif self.render_mode == "human":
-            self._get_viewer(self.render_mode).render()
+        return self.mujoco_renderer.render(self.render_mode)
 
-    def _get_viewer(
-        self, mode
-    ) -> Union["gym.envs.mujoco.Viewer", "gym.envs.mujoco.RenderContextOffscreen"]:
-        self.viewer = self._viewers.get(mode)
-        if self.viewer is None:
-            if mode == "human":
-                from gymnasium.envs.mujoco.mujoco_rendering import Viewer
-
-                self.viewer = Viewer(self.model, self.data)
-            elif mode in {
-                "rgb_array",
-                "rgb_array_list",
-            }:
-                from gymnasium.envs.mujoco.mujoco_rendering import (
-                    RenderContextOffscreen,
-                )
-
-                self.viewer = RenderContextOffscreen(model=self.model, data=self.data)
-            self._viewer_setup()
-            self._viewers[mode] = self.viewer
-        return self.viewer
+    def close(self):
+        if self.mujoco_renderer is not None:
+            self.mujoco_renderer.close()
 
     @property
     def dt(self):
@@ -346,6 +321,11 @@ class MujocoPyRobotEnv(BaseRobotEnv):
         elif self.render_mode == "human":
             self._get_viewer(self.render_mode).render()
 
+    def close(self):
+        if self.viewer is not None:
+            self.viewer = None
+            self._viewers = {}
+
     def _get_viewer(
         self, mode
     ) -> Union["mujoco_py.MjViewer", "mujoco_py.MjRenderContextOffscreen"]:
@@ -369,3 +349,9 @@ class MujocoPyRobotEnv(BaseRobotEnv):
 
     def _mujoco_step(self, action):
         self.sim.step()
+
+    def _viewer_setup(self):
+        """Initial configuration of the viewer. Can be used to set the camera position,
+        for example.
+        """
+        pass

--- a/gymnasium_robotics/envs/robot_env.py
+++ b/gymnasium_robotics/envs/robot_env.py
@@ -35,7 +35,6 @@ class BaseRobotEnv(GoalEnv):
         "render_modes": [
             "human",
             "rgb_array",
-            "rgb_array_list",
         ],
         "render_fps": 25,
     }
@@ -309,7 +308,6 @@ class MujocoPyRobotEnv(BaseRobotEnv):
         self._render_callback()
         if self.render_mode in {
             "rgb_array",
-            "rgb_array_list",
         }:
             self._get_viewer(self.render_mode).render(width, height)
             # window size used for old mujoco-py:
@@ -336,7 +334,6 @@ class MujocoPyRobotEnv(BaseRobotEnv):
 
             elif mode in {
                 "rgb_array",
-                "rgb_array_list",
             }:
                 self.viewer = self._mujoco_py.MjRenderContextOffscreen(self.sim, -1)
             self._viewer_setup()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -29,10 +29,12 @@ non_mujoco_py_env_specs = [
 def test_env(spec):
     # Capture warnings
     env = spec.make(disable_env_checker=True).unwrapped
+    
     warnings.simplefilter("always")
     # Test if env adheres to Gym API
     with warnings.catch_warnings(record=True) as w:
-        check_env(env)
+        check_env(env, skip_render_check=True)
+        env.close()
     for warning in w:
         if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise Error(f"Unexpected warning: {warning.message}")

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -29,7 +29,7 @@ non_mujoco_py_env_specs = [
 def test_env(spec):
     # Capture warnings
     env = spec.make(disable_env_checker=True).unwrapped
-    
+
     warnings.simplefilter("always")
     # Test if env adheres to Gym API
     with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
# Description
This PR updates the rendering API of the mujoco environments to the new `MujocoRenderer` class in Gymnasium v0.27.0
https://github.com/Farama-Foundation/Gymnasium/pull/112

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
