### PR TITLE
Add sparse reward variants for Adroit hand environments

### DIFF
--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -1079,31 +1079,40 @@ def register_robotics_envs():
             ),
             max_episode_steps=800,
         )
-        
-        
-    register(
-        id="AdroitHandDoor-v0",
-        entry_point="gymnasium_robotics.envs:AdroitHandDoorEnv",
-        max_episode_steps=200,
-    )
 
-    register(
-        id="AdroitHandHammer-v0",
-        entry_point="gymnasium_robotics.envs:AdroitHandHammerEnv",
-        max_episode_steps=200,
-    )
 
-    register(
-        id="AdroitHandPen-v0",
-        entry_point="gymnasium_robotics.envs:AdroitHandPenEnv",
-        max_episode_steps=200,
-    )
+    for reward_type in ["sparse", "dense"]:
+        suffix = "Sparse" if reward_type == "sparse" else ""
+        kwargs = {
+            "reward_type": reward_type,
+        }
 
-    register(
-        id="AdroitHandRelocate-v0",
-        entry_point="gymnasium_robotics.envs:AdroitHandRelocateEnv",
-        max_episode_steps=200,
-    )
+        register(
+            id=f"AdroitHandDoor{suffix}-v0",
+            entry_point="gymnasium_robotics.envs:AdroitHandDoorEnv",
+            max_episode_steps=200,
+            kwargs=kwargs,
+        )
 
+        register(
+            id=f"AdroitHandHammer{suffix}-v0",
+            entry_point="gymnasium_robotics.envs:AdroitHandHammerEnv",
+            max_episode_steps=200,
+            kwargs=kwargs,
+        )
+
+        register(
+            id=f"AdroitHandPen{suffix}-v0",
+            entry_point="gymnasium_robotics.envs:AdroitHandPenEnv",
+            max_episode_steps=200,
+            kwargs=kwargs,
+        )
+
+        register(
+            id=f"AdroitHandRelocate{suffix}-v0",
+            entry_point="gymnasium_robotics.envs:AdroitHandRelocateEnv",
+            max_episode_steps=200,
+            kwargs=kwargs,
+        )
 
 __version__ = "1.1.0"

--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -1080,7 +1080,6 @@ def register_robotics_envs():
             max_episode_steps=800,
         )
 
-
     for reward_type in ["sparse", "dense"]:
         suffix = "Sparse" if reward_type == "sparse" else ""
         kwargs = {
@@ -1114,5 +1113,6 @@ def register_robotics_envs():
             max_episode_steps=200,
             kwargs=kwargs,
         )
+
 
 __version__ = "1.1.0"

--- a/gymnasium_robotics/envs/adroit_hand/door.py
+++ b/gymnasium_robotics/envs/adroit_hand/door.py
@@ -32,17 +32,19 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
             model_path=xml_file_path,
             frame_skip=5,
             observation_space=observation_space,
-            **kwargs
+            **kwargs,
         )
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
         if reward_type.lower() == "dense":
             self.sparse_reward = False
-        elif reward_type.lower() == "sparse"
+        elif reward_type.lower() == "sparse":
             self.sparse_reward = True
         else:
-            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
+            raise ValueError(
+                f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}"
+            )
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(

--- a/gymnasium_robotics/envs/adroit_hand/door.py
+++ b/gymnasium_robotics/envs/adroit_hand/door.py
@@ -18,7 +18,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
         "render_fps": 100,
     }
 
-    def __init__(self, sparse_reward=False, **kwargs):
+    def __init__(self, reward_type: str = "dense", **kwargs):
         xml_file_path = path.join(
             path.dirname(path.realpath(__file__)),
             "../assets/adroit_hand/adroit_door.xml",
@@ -37,7 +37,12 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
-        self.sparse_reward = sparse_reward
+        if reward_type.lower() == "dense":
+            self.sparse_reward = False
+        elif reward_type.lower() == "sparse"
+            self.sparse_reward = True
+        else:
+            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(

--- a/gymnasium_robotics/envs/adroit_hand/hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/hammer.py
@@ -19,7 +19,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         "render_fps": 100,
     }
 
-    def __init__(self, sparse_reward=False, **kwargs):
+    def __init__(self, reward_type: str = "dense", **kwargs):
         xml_file_path = path.join(
             path.dirname(path.realpath(__file__)),
             "../assets/adroit_hand/adroit_hammer.xml",
@@ -38,7 +38,12 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
-        self.sparse_reward = sparse_reward
+        if reward_type.lower() == "dense":
+            self.sparse_reward = False
+        elif reward_type.lower() == "sparse"
+            self.sparse_reward = True
+        else:
+            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(

--- a/gymnasium_robotics/envs/adroit_hand/hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/hammer.py
@@ -33,17 +33,19 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
             model_path=xml_file_path,
             frame_skip=5,
             observation_space=observation_space,
-            **kwargs
+            **kwargs,
         )
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
         if reward_type.lower() == "dense":
             self.sparse_reward = False
-        elif reward_type.lower() == "sparse"
+        elif reward_type.lower() == "sparse":
             self.sparse_reward = True
         else:
-            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
+            raise ValueError(
+                f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}"
+            )
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(

--- a/gymnasium_robotics/envs/adroit_hand/pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/pen.py
@@ -19,7 +19,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         "render_fps": 100,
     }
 
-    def __init__(self, **kwargs):
+    def __init__(self, sparse_reward=False, **kwargs):
         self.pen_length = 1.0
         self.tar_length = 1.0
 
@@ -38,6 +38,9 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
             **kwargs
         )
         self._model_names = MujocoModelNames(self.model)
+
+        # whether to have sparse rewards
+        self.sparse_reward = sparse_reward
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(
@@ -110,10 +113,10 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
 
         # pos cost
         dist = np.linalg.norm(obj_pos - desired_loc)
-        reward = -dist
+        reward = -dist * (not self.sparse_reward)
         # orien cost
         orien_similarity = np.dot(obj_orien, desired_orien)
-        reward += orien_similarity
+        reward += orien_similarity * (not self.sparse_reward)
 
         # bonus for being close to desired orientation
         if dist < 0.075 and orien_similarity > 0.9:

--- a/gymnasium_robotics/envs/adroit_hand/pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/pen.py
@@ -19,7 +19,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         "render_fps": 100,
     }
 
-    def __init__(self, sparse_reward=False, **kwargs):
+    def __init__(self, reward_type: str = "dense", **kwargs):
         self.pen_length = 1.0
         self.tar_length = 1.0
 
@@ -40,7 +40,12 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
-        self.sparse_reward = sparse_reward
+        if reward_type.lower() == "dense":
+            self.sparse_reward = False
+        elif reward_type.lower() == "sparse"
+            self.sparse_reward = True
+        else:
+            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(

--- a/gymnasium_robotics/envs/adroit_hand/pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/pen.py
@@ -35,17 +35,19 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
             model_path=xml_file_path,
             frame_skip=5,
             observation_space=observation_space,
-            **kwargs
+            **kwargs,
         )
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
         if reward_type.lower() == "dense":
             self.sparse_reward = False
-        elif reward_type.lower() == "sparse"
+        elif reward_type.lower() == "sparse":
             self.sparse_reward = True
         else:
-            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
+            raise ValueError(
+                f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}"
+            )
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(

--- a/gymnasium_robotics/envs/adroit_hand/relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/relocate.py
@@ -32,17 +32,19 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
             model_path=xml_file_path,
             frame_skip=5,
             observation_space=observation_space,
-            **kwargs
+            **kwargs,
         )
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
         if reward_type.lower() == "dense":
             self.sparse_reward = False
-        elif reward_type.lower() == "sparse"
+        elif reward_type.lower() == "sparse":
             self.sparse_reward = True
         else:
-            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
+            raise ValueError(
+                f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}"
+            )
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(

--- a/gymnasium_robotics/envs/adroit_hand/relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/relocate.py
@@ -18,7 +18,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         "render_fps": 100,
     }
 
-    def __init__(self, sparse_reward=False, **kwargs):
+    def __init__(self, reward_type: str = "dense", **kwargs):
         xml_file_path = path.join(
             path.dirname(path.realpath(__file__)),
             "../assets/adroit_hand/adroit_relocate.xml",
@@ -37,7 +37,12 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         self._model_names = MujocoModelNames(self.model)
 
         # whether to have sparse rewards
-        self.sparse_reward = sparse_reward
+        if reward_type.lower() == "dense":
+            self.sparse_reward = False
+        elif reward_type.lower() == "sparse"
+            self.sparse_reward = True
+        else:
+            raise ValueError(f"Unknown reward type, expected `dense` or `sparse` but got {reward_type}")
 
         # Override action_space to -1, 1
         self.action_space = spaces.Box(


### PR DESCRIPTION
# Description

This adds a sparse reward variant to the adroit hand environments.
The dense reward environment is unchanged, but to enable sparse reward on, for example, `AdroitHandPen-v0`, we can now do `AdroitHandPenSparse-v0`.

The sparse reward versions are intentionally very hard, and unlikely to work for status quo RL algorithms without prior heuristics.