### PR TITLE
Remove redundant environment registration

### DIFF
--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -997,18 +997,6 @@ def register_robotics_envs():
         )
 
         register(
-            id=f"PointMaze_Open{suffix}-v3",
-            entry_point="gymnasium_robotics.envs:PointMazeEnv",
-            kwargs=_merge(
-                {
-                    "maze_map": maps.OPEN,
-                },
-                kwargs,
-            ),
-            max_episode_steps=300,
-        )
-
-        register(
             id=f"PointMaze_Medium{suffix}-v3",
             entry_point="gymnasium_robotics.envs:PointMazeEnv",
             kwargs=_merge(
@@ -1079,8 +1067,7 @@ def register_robotics_envs():
             ),
             max_episode_steps=800,
         )
-        
-        
+
     register(
         id="AdroitHandDoor-v0",
         entry_point="gymnasium_robotics.envs:AdroitHandDoorEnv",

--- a/gymnasium_robotics/envs/hand/manipulate.py
+++ b/gymnasium_robotics/envs/hand/manipulate.py
@@ -487,7 +487,6 @@ class MujocoPyManipulateEnv(get_base_manipulate_env(MujocoPyHandEnv)):
         }
 
 
-
 class MujocoHandBlockEnv(MujocoManipulateEnv, EzPickle):
     # noqa: D415
     """


### PR DESCRIPTION
# Description

Fix redundant registration of `PointMaze_Open-v3` environment.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
