### PR TITLE
Solve package name import issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,6 @@ __root__ = "gymnasium_robotics.__init__:register_robotics_envs"
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.packages.find]
-include = ["robotics", "robotics.*"]
-
 [tool.setuptools.package-data]
 gymnasium_robotics = [
     "envs/assets/LICENSE.md",


### PR DESCRIPTION
# Description

The package name in `pyproject.toml` for the configuration `setuptools.packages.find` is set incorrectly to `robotics` instead of `gymnasium_robotics`. Due to this the package can't be imported. 

As specified in https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html, there is no need to add this configuration since setuptools will automatically detect the package directory and name.

This PR removes `setuptools.packages.find` from `pyproject.toml`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
