### PR TITLE
enable `pyright.reportOptionalMemberAccess`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,3 @@ enableTypeIgnoreComments = true
 
 reportMissingImports = "none"
 reportGeneralTypeIssues = "none"  # -> commented out raises 489 errors
-# reportUntypedFunctionDecorator = "none"  # -> pytest.mark.parameterize issues
-reportOptionalMemberAccess = "none" # -> raise _version.py error
-


### PR DESCRIPTION
There is no reason for it to be disabled in this repo, no errors are generated
