### PR TITLE
MaMuJoCo documentation updates

### DIFF
--- a/docs/envs/MaMuJoCo/index.md
+++ b/docs/envs/MaMuJoCo/index.md
@@ -16,12 +16,13 @@ There are 2 types of Environments, included (1) multi-agent factorizations of [G
 
 Gymansium-Robotics/MaMuJoCo Represents the first, easy to use Framework for research of agent factorization
 
-The unique dependencies for this set of environments can be installed via:
+The `mamujoco` are not included in the current `1.2.0` release of `Gymnasium-Robotics` since we are performing some evaluation tests. If you want to try the current implementation of these environments please install them from source:
 
 ```sh
-pip install gymnasium-robotics[mamujoco]
+git clone https://github.com/Farama-Foundation/Gymnasium-Robotics.git
+cd Gymnasium-Robotics
+pip install -e.
 ```
-
 
 ## API
 

--- a/docs/envs/MaMuJoCo/ma_ant.md
+++ b/docs/envs/MaMuJoCo/ma_ant.md
@@ -167,9 +167,3 @@ Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https:
 	- Fixed diagonal factorization ("2x4d") not being diagonal.
 	- Fixed Global observations (The Ant's Torso: `rootx`, `rooty`, `rootz`) not being observed.
 	- Changed action ordering to be same as [Gymnasium/MuJoCo/Ant](https://gymnasium.farama.org/environments/mujoco/ant/#action-space)
-
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_coupled_half_cheetah.md
+++ b/docs/envs/MaMuJoCo/ma_coupled_half_cheetah.md
@@ -104,8 +104,3 @@ Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https:
  	- Improved node naming
 	- Changed action ordering to be same as [Gymnasium/MuJoCo/HalfCheetah](https://gymnasium.farama.org/environments/mujoco/half_cheetah/#action-space)
 
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_half_cheetah.md
+++ b/docs/envs/MaMuJoCo/ma_half_cheetah.md
@@ -130,7 +130,3 @@ Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https:
 	- Changed action ordering to be same as [Gymnasium/MuJoCo/HalfCheetah](https://gymnasium.farama.org/environments/mujoco/half_cheetah/#action-space)
 
 
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_hopper.md
+++ b/docs/envs/MaMuJoCo/ma_hopper.md
@@ -89,7 +89,3 @@ Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https:
 	- Fixed Global observations (The Hopper's top: `rootx`, `rooty`, `rootz`) not being observed.
 
 
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_humanoid.md
+++ b/docs/envs/MaMuJoCo/ma_humanoid.md
@@ -119,8 +119,3 @@ Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https:
 	- Added support for body observations (`cvel`, `cinert`, `cfrc_ext`)
 	- Changed action ordering to be same as [Gymnasium/MuJoCo/Humanoid](https://gymnasium.farama.org/environments/mujoco/humanoid/#action-space)
 
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_humanoid_standup.md
+++ b/docs/envs/MaMuJoCo/ma_humanoid_standup.md
@@ -118,9 +118,3 @@ Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https:
 	- Fixed abdomen observations ordering.
 	- Added support for body observations (`cvel`, `cinert`, `cfrc_ext`)
 	- Changed action ordering to be same as [Gymnasium/MuJoCo/Humanoid](https://gymnasium.farama.org/environments/mujoco/humanoid/#action-space)
-
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_pusher.md
+++ b/docs/envs/MaMuJoCo/ma_pusher.md
@@ -99,8 +99,3 @@ All agent terminate and truncate at same time given the same conditions as [Gymn
 
 ## Version History
 - v0: Initial version release, uses [Gymnasium.MuJoCo-v4](https://gymnasium.farama.org/environments/mujoco/), first implemented here.
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_reacher.md
+++ b/docs/envs/MaMuJoCo/ma_reacher.md
@@ -82,8 +82,3 @@ All agent terminate and truncate at the same time, given the same conditions as 
 Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https://github.com/schroederdewitt/multiagent_mujoco)):
 	- Added/Fixed Global observations (The Targets's coordinates: `targetx`, `targety`) not being observed.
 
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_single.md
+++ b/docs/envs/MaMuJoCo/ma_single.md
@@ -41,8 +41,3 @@ The agent terminates and truncates at the same time, given the same conditions a
 v0: Initial version release, uses [Gymnasium.MuJoCo-v4](https://gymnasium.farama.org/environments/mujoco/), and is a fork of [the original multiagent_mujuco](https://github.com/schroederdewitt/multiagent_mujoco).
 No Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https://github.com/schroederdewitt/multiagent_mujoco)).
 
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_swimmer.md
+++ b/docs/envs/MaMuJoCo/ma_swimmer.md
@@ -80,8 +80,3 @@ All agent terminate and truncate at the same time, given the same conditions as 
 Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https://github.com/schroederdewitt/multiagent_mujoco)):
 	- Added/Fixed Global observations (The Swimmer's front tip: `free_body_rot`) not being observed.
 
-
-
-```{toctree}
-:hidden:
-```

--- a/docs/envs/MaMuJoCo/ma_walker2d.md
+++ b/docs/envs/MaMuJoCo/ma_walker2d.md
@@ -94,9 +94,3 @@ All agent terminate and truncate at the same time given the same conditions as [
 - v0: Initial version release, uses [Gymnasium.MuJoCo-v4](https://gymnasium.farama.org/environments/mujoco/), and is a fork of the original MaMuJoCo [schroederdewitt/multiagent_mujoco](https://github.com/schroederdewitt/multiagent_mujoco).
 Changes from the original `MaMuJoCo` ([schroederdewitt/multiagent_mujoco](https://github.com/schroederdewitt/multiagent_mujoco)):
 	- Added/Fixed Global observations (The Walker's top: `rootx`, `rooty`, `rootz`) not being observed.
-
-
-
-```{toctree}
-:hidden:
-```


### PR DESCRIPTION
# Description

Some documentation updates:
* Note about installing `mamujoco` from source in current `1.2.0` `Gymnasium-Robotics` release. #95
* Remove tabs from environments in webpage

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
