### PR TITLE
Add missing underscore to fix rendering

### DIFF
--- a/gymnasium_robotics/envs/fetch/fetch_env.py
+++ b/gymnasium_robotics/envs/fetch/fetch_env.py
@@ -238,7 +238,7 @@ class MujocoPyFetchEnv(get_base_fetch_env(MujocoPyRobotEnv)):
         self.sim.forward()
 
     def _viewer_setup(self):
-        lookat = self.get_gripper_xpos()
+        lookat = self._get_gripper_xpos()
         for idx, value in enumerate(lookat):
             self.viewer.cam.lookat[idx] = value
         assert self.viewer is not None


### PR DESCRIPTION
# Description
Rendering the fetch environment raises an error, that `get_gripper_xpos` is not defined.
Looking into the code, I noticed that the leading underscore is missing, changing it from `self.get_gripper_xpos` to `self._get_gripper_xpos` resolved the issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
