### PR TITLE
Correct point_obs slicing for achieved_goal in point_maze environments

### DIFF
--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -389,7 +389,7 @@ class PointMazeEnv(MazeEnv, EzPickle):
         )
 
     def _get_obs(self, point_obs) -> Dict[str, np.ndarray]:
-        achieved_goal = point_obs[2:]
+        achieved_goal = point_obs[:2]
         return {
             "observation": point_obs.copy(),
             "achieved_goal": achieved_goal.copy(),


### PR DESCRIPTION
# Description

Hello!

Right now [`achieved_goal = point_obs[2:]`](https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/gymnasium_robotics/envs/maze/point_maze.py#L392) refers to velocities while it should be x, y positions instead (desired_goal is a position).
[`point_obs`](https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/gymnasium_robotics/envs/maze/point_maze.py#L392) is eventually coming from [`np.concatenate([self.data.qpos, self.data.qvel]).ravel()`](https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/gymnasium_robotics/envs/maze/point.py#L71) in the `PointEnv`.

This PR corrects the slicing s.t. `achieved_goal = point_obs[:2]` refers to x, y positions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
