### PR TITLE
update the position of the goal every reset in AntMaze environment

### DIFF
--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -292,9 +292,6 @@ class MazeEnv(GoalEnv):
             # Add noise to goal position
             self.goal = self.add_xy_position_noise(goal)
 
-            # Update the position of the target site for visualization
-            self.update_target_site_pos()
-
             if "reset_cell" in options and options["reset_cell"] is not None:
                 # assert that goal cell is valid
                 assert self.maze.map_length > options["reset_cell"][1]
@@ -311,6 +308,8 @@ class MazeEnv(GoalEnv):
             else:
                 reset_pos = self.generate_reset_pos()
 
+        # Update the position of the target site for visualization
+        self.update_target_site_pos()
         # Add noise to reset position
         self.reset_pos = self.add_xy_position_noise(reset_pos)
 


### PR DESCRIPTION
# Description

When we modify the goal position of maze_map, the visualization does not change at all, while the goal in the code was right. I found the position of the goal in visualization only updated when `goal-cell` was passed in `options`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

```
import gymnasium as gym

example_map = [
       [1, 1, 1, 1, 1],
       [1, "r", 0, "g", 1],
       [1, 1, 1, 0, 1]
]
env = gym.make('AntMaze_UMaze-v3', render_mode='human', maze_map=example_map)
```

| Before | After |
| ------ | ----- |
| <img width="1002" alt="image" src="https://user-images.githubusercontent.com/17773634/217991144-25e72535-486c-447a-9a01-17ffee21d6e4.png"> | <img width="1072" alt="image" src="https://user-images.githubusercontent.com/17773634/217991253-f2d3ba8e-ff6b-4105-b71a-fb1beb296bc0.png"> |

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes