### PR TITLE
Update pointmaze

### DIFF
--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -166,7 +166,7 @@ class Maze:
         worldbody = tree.find(".//worldbody")
 
         maze = cls(maze_map, maze_size_scaling, maze_height)
-
+        empty_locations = []
         for i in range(maze.map_length):
             for j in range(maze.map_width):
                 struct = maze_map[i][j]
@@ -188,18 +188,14 @@ class Maze:
                         rgba="0.7 0.5 0.3 1.0",
                     )
 
-                elif maze_map[i][j] in [
-                    RESET,
-                ]:
+                elif struct == RESET:
                     maze._unique_reset_locations.append(np.array([x, y]))
-                elif maze_map[i][j] in [
-                    GOAL,
-                ]:
+                elif struct == GOAL:
                     maze._unique_goal_locations.append(np.array([x, y]))
-                elif maze_map[i][j] in [
-                    COMBINED,
-                ]:
+                elif struct == COMBINED:
                     maze._combined_locations.append(np.array([x, y]))
+                elif struct == 0:
+                    empty_locations.append(np.array([x, y]))
 
         # Add target site for visualization
         ET.SubElement(
@@ -213,6 +209,14 @@ class Maze:
         )
 
         # Add the combined cell locations (goal/reset) to goal and reset
+        if (
+            not maze._unique_goal_locations
+            and not maze._unique_reset_locations
+            and not maze._combined_locations
+        ):
+            # If there are no given "r", "g" or "c" cells in the maze data structure,
+            # any empty cell can be a reset or goal location at initialization.
+            maze._combined_locations = empty_locations
         maze._unique_goal_locations += maze._combined_locations
         maze._unique_reset_locations += maze._combined_locations
 

--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -10,7 +10,7 @@ As well as adding support for the Gymnasium API.
 
 This project is covered by the Apache 2.0 License.
 """
-
+import math
 import tempfile
 import xml.etree.ElementTree as ET
 from os import path
@@ -133,6 +133,12 @@ class Maze:
         y = self.y_map_center - (rowcol_pos[0] + 0.5) * self.maze_size_scaling
 
         return np.array([x, y])
+
+    def cell_xy_to_rowcol(self, xy_pos: np.ndarray) -> np.ndarray:
+        """Converts a cell x and y coordinates to `(i,j)`"""
+        i = math.floor((self.y_map_center - xy_pos[1]) / self.maze_size_scaling)
+        j = math.floor((xy_pos[0] + self.x_map_center) / self.maze_size_scaling)
+        return np.array([i, j])
 
     @classmethod
     def make_maze(

--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -60,8 +60,8 @@ class Maze:
         # Get the center cell Cartesian position of the maze. This will be the origin
         self._map_length = len(maze_map)
         self._map_width = len(maze_map[0])
-        self._x_map_center = np.ceil(self.map_width / 2) * maze_size_scaling
-        self._y_map_center = np.ceil(self.map_length / 2) * maze_size_scaling
+        self._x_map_center = self.map_width / 2 * maze_size_scaling
+        self._y_map_center = self.map_length / 2 * maze_size_scaling
 
     @property
     def maze_map(self) -> List[List[Union[str, int]]]:

--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -129,8 +129,8 @@ class Maze:
 
     def cell_rowcol_to_xy(self, rowcol_pos: np.ndarray) -> np.ndarray:
         """Converts a cell index `(i,j)` to x and y coordinates in the MuJoCo simulation"""
-        x = rowcol_pos[1] - self.x_map_center
-        y = rowcol_pos[0] - self.y_map_center
+        x = (rowcol_pos[1] + 0.5) * self.maze_size_scaling - self.x_map_center
+        y = self.y_map_center - (rowcol_pos[0] + 0.5) * self.maze_size_scaling
 
         return np.array([x, y])
 

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -369,6 +369,9 @@ class PointMazeEnv(MazeEnv, EzPickle):
 
         obs, info = self.point_env.reset(seed=seed)
         obs_dict = self._get_obs(obs)
+        info["success"] = bool(
+            np.linalg.norm(obs_dict["achieved_goal"] - self.goal) <= 0.45
+        )
 
         return obs_dict, info
 
@@ -376,10 +379,13 @@ class PointMazeEnv(MazeEnv, EzPickle):
         obs, _, _, _, info = self.point_env.step(action)
         obs_dict = self._get_obs(obs)
 
+        info["success"] = bool(
+            np.linalg.norm(obs_dict["achieved_goal"] - self.goal) <= 0.45
+        )
+        reward = self.compute_reward(obs_dict["achieved_goal"], self.goal, info)
+
         terminated = self.compute_terminated(obs_dict["achieved_goal"], self.goal, info)
         truncated = self.compute_truncated(obs_dict["achieved_goal"], self.goal, info)
-
-        reward = self.compute_reward(obs_dict["achieved_goal"], self.goal, info)
 
         return obs_dict, reward, terminated, truncated, info
 

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -50,8 +50,9 @@ class PointMazeEnv(MazeEnv, EzPickle):
     * `"r": str` - Indicates cells in which the agent can be initialized in when the environment is reset.
     * `"c": str` - Stands for combined cell and indicates that this cell can be initialized as a goal or agent reset location.
 
-    The maze data structure is discrete. However the observations are continuous and variance is added to the goal and the agent's initial pose by adding a sammpled noise from a uniform distribution
-    to the cell cartesian coordinate center in the MuJoCo simulation.
+    Note that if all the empty cells are given a value of `0` and there are no cells in the map representation with values `"g"`, `"r"`, or `"c"`, the initial goal and reset locations
+    will be randomly chosen from the empty cells with value `0`. Also, the maze data structure is discrete. However the observations are continuous and variance is added to the goal and the
+    agent's initial pose by adding a sammpled noise from a uniform distribution to the cell's `(x,y)` coordinates in the MuJoCo simulation.
 
     #### Maze size
 


### PR DESCRIPTION
# Description
This PR adds some fixes to the `PointMaze` environments:
- Fix the calculation for the x, y simulation coordinates of the center of the maze
- Now, if a `maze_map` description is passed such that there are no "g", "r", or "c" cells, the initial goal and reset cells will be chosen randomly from the empty cells represented with `0`. Read documentation for more information about the map data structure representation https://robotics.farama.org/envs/maze/point_maze/#maze-variations
- Add `success` key to infos return dictionary
- Reduce target success threshold from 0.5 to 0.45

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
