### PR TITLE
Resparsify adroit hand envs

### DIFF
--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -286,7 +286,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
         if self.render_mode == "human":
             self.render()
 
-        return obs, reward, goal_achieved, False, dict(success=goal_achieved)
+        return obs, reward, False, False, dict(success=goal_achieved)
 
     def _get_obs(self):
         # qpos for hand

--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -133,7 +133,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
     - `door_hinge_displacement`: adds a positive reward of `2` if the door hinge is opened more than `0.2` radians, `8` if more than `1.0` randians, and `10` if more than `1.35` radians.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandDoorSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and 0 otherwise.
+    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -259,7 +259,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = self.data.qpos[self.door_hinge_addrs]
         goal_achieved = True if goal_distance >= 1.35 else False
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 100.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -133,7 +133,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
     - `door_hinge_displacement`: adds a positive reward of `2` if the door hinge is opened more than `0.2` radians, `8` if more than `1.0` randians, and `10` if more than `1.35` radians.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandDoorSparse-v1')`.
-    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -259,7 +259,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = self.data.qpos[self.door_hinge_addrs]
         goal_achieved = True if goal_distance >= 1.35 else False
-        reward = 100.0 if goal_achieved else -0.1
+        reward = 1.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -133,7 +133,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
     - `door_hinge_displacement`: adds a positive reward of `2` if the door hinge is opened more than `0.2` radians, `8` if more than `1.0` randians, and `10` if more than `1.35` radians.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandDoorSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 10 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -259,7 +259,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = self.data.qpos[self.door_hinge_addrs]
         goal_achieved = True if goal_distance >= 1.35 else False
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 10.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -142,7 +142,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
     - `hammer_nail`: adds a positive reward the closer the head of the nail is to the board. `25` if the distance is less than `0.02` meters and `75` if it is less than `0.01` meters.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandHammerSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and 0 otherwise.
+    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -272,7 +272,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = np.linalg.norm(nail_pos - goal_pos)
         goal_achieved = True if goal_distance < 0.01 else False
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 100.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -142,7 +142,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
     - `hammer_nail`: adds a positive reward the closer the head of the nail is to the board. `25` if the distance is less than `0.02` meters and `75` if it is less than `0.01` meters.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandHammerSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 10 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -272,7 +272,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = np.linalg.norm(nail_pos - goal_pos)
         goal_achieved = True if goal_distance < 0.01 else False
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 10.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -142,7 +142,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
     - `hammer_nail`: adds a positive reward the closer the head of the nail is to the board. `25` if the distance is less than `0.02` meters and `75` if it is less than `0.01` meters.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandHammerSparse-v1')`.
-    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -272,7 +272,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = np.linalg.norm(nail_pos - goal_pos)
         goal_achieved = True if goal_distance < 0.01 else False
-        reward = 100.0 if goal_achieved else -0.1
+        reward = 1.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -298,7 +298,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         if self.render_mode == "human":
             self.render()
 
-        return obs, reward, goal_achieved, False, dict(success=goal_achieved)
+        return obs, reward, False, False, dict(success=goal_achieved)
 
     def _get_obs(self):
         # qpos for hand

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -134,7 +134,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
     - `dropping_pen`: If the pen drops from the hand (pen's height less than `0.075`) add a negative reward of `5`.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandPenSparse-v1')`.
-    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -280,7 +280,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         goal_achieved = (
             True if (goal_distance < 0.075 and orien_similarity > 0.95) else False
         )
-        reward = 100.0 if goal_achieved else -0.1
+        reward = 1.0 if goal_achieved else -0.1
         goal_failed = obj_pos[2] < 0.075
 
         # override reward if not sparse reward

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -277,7 +277,9 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = np.linalg.norm(obj_pos - desired_loc)
         orien_similarity = np.dot(obj_orien, desired_orien)
-        goal_achieved = True if (goal_distance < 0.075 and orien_similarity > 0.95) else False
+        goal_achieved = (
+            True if (goal_distance < 0.075 and orien_similarity > 0.95) else False
+        )
         reward = 1.0 if goal_achieved else -0.1
         goal_failed = obj_pos[2] < 0.075
 
@@ -298,7 +300,13 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         if self.render_mode == "human":
             self.render()
 
-        return obs, reward, goal_failed or goal_achieved, False, dict(success=goal_achieved)
+        return (
+            obs,
+            reward,
+            goal_failed or goal_achieved,
+            False,
+            dict(success=goal_achieved),
+        )
 
     def _get_obs(self):
         qpos = self.data.qpos.ravel()

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -39,7 +39,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
 
     ## Action Space
 
-    The action space is a Box(-1.0, 1.0, (24,), float32)`. The control actions are absolute angular positions of the Adroit hand joints. The input of the control actions is set to a range between -1 and 1 by scaling the real actuator angle ranges in radians.
+    The action space is a `Box(-1.0, 1.0, (24,), float32)`. The control actions are absolute angular positions of the Adroit hand joints. The input of the control actions is set to a range between -1 and 1 by scaling the real actuator angle ranges in radians.
     The elements of the action array are the following:
 
     | Num | Action                                                                                  | Control Min | Control Max | Angle Min    | Angle Max   | Name (in corresponding XML file) | Joint | Unit        |

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -39,7 +39,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
 
     ## Action Space
 
-    The action space is a `Box(-1.0, 1.0, (24,), float32)`. The control actions are absolute angular positions of the Adroit hand joints. The input of the control actions is set to a range between -1 and 1 by scaling the real actuator angle ranges in radians.
+    The action space is a Box(-1.0, 1.0, (24,), float32)`. The control actions are absolute angular positions of the Adroit hand joints. The input of the control actions is set to a range between -1 and 1 by scaling the real actuator angle ranges in radians.
     The elements of the action array are the following:
 
     | Num | Action                                                                                  | Control Min | Control Max | Angle Min    | Angle Max   | Name (in corresponding XML file) | Joint | Unit        |
@@ -134,10 +134,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
     - `dropping_pen`: If the pen drops from the hand (pen's height less than `0.075`) add a negative reward of `5`.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandPenSparse-v1')`.
-    In this variant, the environment returns the following `sparse` reward function that consists of the following parts:
-    - `dropping_pen`: If the pen drops from the hand (pen's height less than `0.075`) add a negative reward of `5`.
-    - `close_to_target`: bonus reward for the pen being close to the target orientation. If the dot product between both ortientations is greater than `0.9` and the Euclidean
-        distance less than `0.075` add a `10` reward, if the same distance holds and the orientation dot product is greater than `0.95` add `50`.
+    In this variant, the environment returns a reward of 1 for environment success and 0 otherwise.
 
     ## Starting State
 
@@ -277,31 +274,31 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
             - self.data.site_xpos[self.tar_b_site_id]
         ) / self.tar_length
 
-        # pos cost
-        dist = np.linalg.norm(obj_pos - desired_loc)
-        reward = -dist * (not self.sparse_reward)
-        # orien cost
+        # compute the sparse reward variant first
+        goal_distance = np.linalg.norm(obj_pos - desired_loc)
         orien_similarity = np.dot(obj_orien, desired_orien)
-        reward += orien_similarity * (not self.sparse_reward)
+        goal_achieved = True if (goal_distance < 0.075 and orien_similarity > 0.95) else False
+        reward = 1.0 if goal_achieved else -0.1
+        goal_failed = obj_pos[2] < 0.075
 
-        # bonus for being close to desired orientation
-        if dist < 0.075 and orien_similarity > 0.9:
-            reward += 10
-        if dist < 0.075 and orien_similarity > 0.95:
-            reward += 50
+        # override reward if not sparse reward
+        if not self.sparse_reward:
+            reward = -goal_distance + orien_similarity
 
-        # penalty for dropping the pen
-        terminated = False
-        if obj_pos[2] < 0.075:
-            reward -= 5
-            terminated = True
+            # bonus for being close to desired orientation
+            if goal_distance < 0.075 and orien_similarity > 0.9:
+                reward += 10
+            if goal_distance < 0.075 and orien_similarity > 0.95:
+                reward += 50
 
-        goal_achieved = True if (dist < 0.075 and orien_similarity > 0.95) else False
+            # penalty for dropping the pen
+            if obj_pos[2] < 0.075:
+                reward -= 5
 
         if self.render_mode == "human":
             self.render()
 
-        return obs, reward, terminated, False, dict(success=goal_achieved)
+        return obs, reward, goal_failed or goal_achieved, False, dict(success=goal_achieved)
 
     def _get_obs(self):
         qpos = self.data.qpos.ravel()

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -134,7 +134,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
     - `dropping_pen`: If the pen drops from the hand (pen's height less than `0.075`) add a negative reward of `5`.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandPenSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and 0 otherwise.
+    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -280,7 +280,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         goal_achieved = (
             True if (goal_distance < 0.075 and orien_similarity > 0.95) else False
         )
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 100.0 if goal_achieved else -0.1
         goal_failed = obj_pos[2] < 0.075
 
         # override reward if not sparse reward

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -134,7 +134,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
     - `dropping_pen`: If the pen drops from the hand (pen's height less than `0.075`) add a negative reward of `5`.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandPenSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 10 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -280,7 +280,7 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         goal_achieved = (
             True if (goal_distance < 0.075 and orien_similarity > 0.95) else False
         )
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 10.0 if goal_achieved else -0.1
 
         # goal_failed = obj_pos[2] < 0.075
 

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -303,7 +303,8 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
         return (
             obs,
             reward,
-            goal_failed or goal_achieved,
+            # goal_failed or goal_achieved,
+            False,
             False,
             dict(success=goal_achieved),
         )

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -281,7 +281,8 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
             True if (goal_distance < 0.075 and orien_similarity > 0.95) else False
         )
         reward = 1.0 if goal_achieved else -0.1
-        goal_failed = obj_pos[2] < 0.075
+
+        # goal_failed = obj_pos[2] < 0.075
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -134,7 +134,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
     - `ball_close_to_target`: bonus of `10` if the ball's Euclidean distance to its target is less than `0.1` meters. Bonus of `20` if the distance is less than `0.05` meters.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandReloateSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 10 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -259,7 +259,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = float(np.linalg.norm(obj_pos - target_pos))
         goal_achieved = True if goal_distance < 0.1 else False
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 10.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -134,8 +134,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
     - `ball_close_to_target`: bonus of `10` if the ball's Euclidean distance to its target is less than `0.1` meters. Bonus of `20` if the distance is less than `0.05` meters.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandReloateSparse-v1')`.
-    In this variant, the environment returns the following `sparse` reward function that consists of the following parts:
-    - `ball_close_to_target`: bonus of `10` if the ball's Euclidean distance to its target is less than `0.1` meters. Bonus of `20` if the distance is less than `0.05` meters.
+    In this variant, the environment returns a reward of 1 for environment success and 0 otherwise.
 
     ## Starting State
 
@@ -257,9 +256,14 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         palm_pos = self.data.site_xpos[self.S_grasp_site_id].ravel()
         target_pos = self.data.site_xpos[self.target_obj_site_id].ravel()
 
-        reward = 0.0
+        # compute the sparse reward variant first
+        goal_distance = float(np.linalg.norm(obj_pos - target_pos))
+        goal_achieved = True if goal_distance < 0.1 else False
+        reward = 1.0 if goal_achieved else -0.1
+
+        # override reward if not sparse reward
         if not self.sparse_reward:
-            reward -= 0.1 * np.linalg.norm(palm_pos - obj_pos)  # take hand to object
+            reward = 0.1 * np.linalg.norm(palm_pos - obj_pos)  # take hand to object
             if obj_pos[2] > 0.04:  # if object off the table
                 reward += 1.0  # bonus for lifting the object
                 reward += -0.5 * np.linalg.norm(
@@ -269,20 +273,18 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
                     obj_pos - target_pos
                 )  # make object go to target
 
-        # bonus for object close to target
-        if np.linalg.norm(obj_pos - target_pos) < 0.1:
-            reward += 10.0
+            # bonus for object close to target
+            if goal_distance < 0.1:
+                reward += 10.0
 
-        # bonus for object "very" close to target
-        if np.linalg.norm(obj_pos - target_pos) < 0.05:
-            reward += 20.0
-
-        goal_achieved = True if np.linalg.norm(obj_pos - target_pos) < 0.1 else False
+            # bonus for object "very" close to target
+            if goal_distance < 0.05:
+                reward += 20.0
 
         if self.render_mode == "human":
             self.render()
 
-        return obs, reward, False, False, dict(success=goal_achieved)
+        return obs, reward, goal_achieved, False, dict(success=goal_achieved)
 
     def _get_obs(self):
         # qpos for hand

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -134,7 +134,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
     - `ball_close_to_target`: bonus of `10` if the ball's Euclidean distance to its target is less than `0.1` meters. Bonus of `20` if the distance is less than `0.05` meters.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandReloateSparse-v1')`.
-    In this variant, the environment returns a reward of 1 for environment success and 0 otherwise.
+    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -259,7 +259,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = float(np.linalg.norm(obj_pos - target_pos))
         goal_achieved = True if goal_distance < 0.1 else False
-        reward = 1.0 if goal_achieved else -0.1
+        reward = 100.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -284,7 +284,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         if self.render_mode == "human":
             self.render()
 
-        return obs, reward, goal_achieved, False, dict(success=goal_achieved)
+        return obs, reward, False, False, dict(success=goal_achieved)
 
     def _get_obs(self):
         # qpos for hand

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -134,7 +134,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
     - `ball_close_to_target`: bonus of `10` if the ball's Euclidean distance to its target is less than `0.1` meters. Bonus of `20` if the distance is less than `0.05` meters.
 
     The `sparse` reward variant of the environment can be initialized by calling `gym.make('AdroitHandReloateSparse-v1')`.
-    In this variant, the environment returns a reward of 100 for environment success and -0.1 otherwise.
+    In this variant, the environment returns a reward of 1 for environment success and -0.1 otherwise.
 
     ## Starting State
 
@@ -259,7 +259,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         # compute the sparse reward variant first
         goal_distance = float(np.linalg.norm(obj_pos - target_pos))
         goal_achieved = True if goal_distance < 0.1 else False
-        reward = 100.0 if goal_achieved else -0.1
+        reward = 1.0 if goal_achieved else -0.1
 
         # override reward if not sparse reward
         if not self.sparse_reward:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "gymnasium>=0.26",
     "PettingZoo>=1.22.2",
     "Jinja2>=3.0.3",
+    "imageio"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
# Description

The previous version of d4rl sparse envs gave a small reward for almost solving the env, and a larger reward for completely solving it. This caused issues where agents tended to exploit the reward structure by staying in configurations where it could perpetually collect the small reward, resulting in a low success rate outright.

This sparsification results in the environment only giving a reward of 1.0 when the environment is solved, and a reward of 0.0 otherwise.
