### PR TITLE
Adroit reset add `initial_state_dict` to options

### DIFF
--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -143,9 +143,9 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset)
     with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
-    
+
     * `qpos`: np.ndarray with shape `(30,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(30,)`, MuJoCo simulation joint velocities
     * `board_body_pos`: np.ndarray with shape `(3,)`, cartesian coordinates of the door body

--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -11,6 +11,7 @@ This project is covered by the Apache 2.0 License.
 """
 
 from os import path
+from typing import Dict, Optional
 
 import numpy as np
 from gymnasium import spaces
@@ -322,10 +323,17 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
             ]
         )
 
-    def reset(self, initial_state_dict=None, *args, **kwargs):
-        obs, info = super().reset(*args, **kwargs)
-        if initial_state_dict is not None:
-            self.set_env_state(initial_state_dict)
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Dict[str, Optional[Dict[str, np.ndarray]]] = {
+            "initial_state_dict": None
+        },
+    ):
+        obs, info = super().reset(seed=seed)
+        if options["initial_state_dict"] is not None:
+            self.set_env_state(options["initial_state_dict"])
             obs = self._get_obs()
 
         return obs, info

--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -143,8 +143,9 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `initial_state_dict` argument. This argument must be a dictionary with the following items:
-
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
+    
     * `qpos`: np.ndarray with shape `(30,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(30,)`, MuJoCo simulation joint velocities
     * `board_body_pos`: np.ndarray with shape `(3,)`, cartesian coordinates of the door body

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -11,7 +11,7 @@ This project is covered by the Apache 2.0 License.
 """
 
 from os import path
-from typing import Dict, Optional
+from typing import Optional
 
 import numpy as np
 from gymnasium import spaces
@@ -266,6 +266,20 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
             self.model.actuator_ctrlrange[:, 1] - self.model.actuator_ctrlrange[:, 0]
         )
 
+        self._state_space = spaces.Dict(
+            {
+                "qpos": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(33,), dtype=np.float64
+                ),
+                "qvel": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(33,), dtype=np.float64
+                ),
+                "board_pos": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(3,), dtype=np.float64
+                ),
+            }
+        )
+
         EzPickle.__init__(self, **kwargs)
 
     def step(self, a):
@@ -340,12 +354,10 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         self,
         *,
         seed: Optional[int] = None,
-        options: Dict[str, Optional[Dict[str, np.ndarray]]] = {
-            "initial_state_dict": None
-        },
+        options: Optional[dict] = None,
     ):
         obs, info = super().reset(seed=seed)
-        if options["initial_state_dict"] is not None:
+        if options is not None and "initial_state_dict" in options:
             self.set_env_state(options["initial_state_dict"])
             obs = self._get_obs()
 
@@ -373,6 +385,9 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         """
         Set the state which includes hand as well as objects and targets in the scene
         """
+        assert self._state_space.contains(
+            state_dict
+        ), f"The state dictionary {state_dict} must be a member of {self._state_space}."
         qp = state_dict["qpos"]
         qv = state_dict["qvel"]
         board_pos = state_dict["board_pos"]

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -152,7 +152,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset)
     with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
 
     * `qpos`: np.ndarray with shape `(33,)`, MuJoCo simulation joint positions

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -11,6 +11,7 @@ This project is covered by the Apache 2.0 License.
 """
 
 from os import path
+from typing import Dict, Optional
 
 import numpy as np
 from gymnasium import spaces
@@ -334,10 +335,17 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
             ]
         )
 
-    def reset(self, initial_state_dict=None, *args, **kwargs):
-        obs, info = super().reset(*args, **kwargs)
-        if initial_state_dict is not None:
-            self.set_env_state(initial_state_dict)
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Dict[str, Optional[Dict[str, np.ndarray]]] = {
+            "initial_state_dict": None
+        },
+    ):
+        obs, info = super().reset(seed=seed)
+        if options["initial_state_dict"] is not None:
+            self.set_env_state(options["initial_state_dict"])
             obs = self._get_obs()
 
         return obs, info

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -152,7 +152,8 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `initial_state_dict` argument. This argument must be a dictionary with the following items:
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
 
     * `qpos`: np.ndarray with shape `(33,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(33,)`, MuJoCo simulation joint velocities

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -11,6 +11,7 @@ This project is covered by the Apache 2.0 License.
 """
 
 from os import path
+from typing import Dict, Optional
 
 import numpy as np
 from gymnasium import spaces
@@ -344,10 +345,17 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
             ]
         )
 
-    def reset(self, initial_state_dict=None, *args, **kwargs):
-        obs, info = super().reset(*args, **kwargs)
-        if initial_state_dict is not None:
-            self.set_env_state(initial_state_dict)
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Dict[str, Optional[Dict[str, np.ndarray]]] = {
+            "initial_state_dict": None
+        },
+    ):
+        obs, info = super().reset(seed=seed)
+        if options["initial_state_dict"] is not None:
+            self.set_env_state(options["initial_state_dict"])
             obs = self._get_obs()
 
         return obs, info

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -144,8 +144,9 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `initial_state_dict` argument. This argument must be a dictionary with the following items:
-
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
+    
     * `qpos`: np.ndarray with shape `(30,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(30,)`, MuJoCo simulation joint velocities
     * `desired_orien`: np.ndarray with shape `(4,)`, quaternion values of the target pen orientation

--- a/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_pen.py
@@ -144,9 +144,9 @@ class AdroitHandPenEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset)
     with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
-    
+
     * `qpos`: np.ndarray with shape `(30,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(30,)`, MuJoCo simulation joint velocities
     * `desired_orien`: np.ndarray with shape `(4,)`, quaternion values of the target pen orientation

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -144,9 +144,9 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset)
     with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
-    
+
     * `qpos`: np.ndarray with shape `(36,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(36,)`, MuJoCo simulation joint velocities
     * `obj_pos`: np.ndarray with shape `(3,)`, cartesian coordinates of the ball object

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -144,8 +144,9 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
 
     The joint values of the environment are deterministically initialized to a zero.
 
-    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `initial_state_dict` argument. This argument must be a dictionary with the following items:
-
+    For reproducibility, the starting state of the environment can also be set when calling `env.reset()` by passing the `options` dictionary argument (https://gymnasium.farama.org/api/env/#gymnasium.Env.reset) 
+    with the `initial_state_dict` key. The `initial_state_dict` key must be a dictionary with the following items:
+    
     * `qpos`: np.ndarray with shape `(36,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(36,)`, MuJoCo simulation joint velocities
     * `obj_pos`: np.ndarray with shape `(3,)`, cartesian coordinates of the ball object

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -11,7 +11,7 @@ This project is covered by the Apache 2.0 License.
 """
 
 from os import path
-from typing import Dict, Optional
+from typing import Optional
 
 import numpy as np
 from gymnasium import spaces
@@ -256,6 +256,23 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
             self.model.actuator_ctrlrange[:, 1] - self.model.actuator_ctrlrange[:, 0]
         )
 
+        self._state_space = spaces.Dict(
+            {
+                "qpos": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(36,), dtype=np.float64
+                ),
+                "qvel": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(36,), dtype=np.float64
+                ),
+                "obj_pos": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(3,), dtype=np.float64
+                ),
+                "target_pos": spaces.Box(
+                    low=-np.inf, high=np.inf, shape=(3,), dtype=np.float64
+                ),
+            }
+        )
+
         EzPickle.__init__(self, **kwargs)
 
     def step(self, a):
@@ -313,12 +330,10 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         self,
         *,
         seed: Optional[int] = None,
-        options: Dict[str, Optional[Dict[str, np.ndarray]]] = {
-            "initial_state_dict": None
-        },
+        options: Optional[dict] = None,
     ):
         obs, info = super().reset(seed=seed)
-        if options["initial_state_dict"] is not None:
+        if options is not None and "initial_state_dict" in options:
             self.set_env_state(options["initial_state_dict"])
             obs = self._get_obs()
 
@@ -368,6 +383,9 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
         """
         Set the state which includes hand as well as objects and targets in the scene
         """
+        assert self._state_space.contains(
+            state_dict
+        ), f"The state dictionary {state_dict} must be a member of {self._state_space}."
         qp = state_dict["qpos"]
         qv = state_dict["qvel"]
 

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -11,6 +11,7 @@ This project is covered by the Apache 2.0 License.
 """
 
 from os import path
+from typing import Dict, Optional
 
 import numpy as np
 from gymnasium import spaces
@@ -307,10 +308,17 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
             [qpos[:-6], palm_pos - obj_pos, palm_pos - target_pos, obj_pos - target_pos]
         )
 
-    def reset(self, initial_state_dict=None, *args, **kwargs):
-        obs, info = super().reset(*args, **kwargs)
-        if initial_state_dict is not None:
-            self.set_env_state(initial_state_dict)
+    def reset(
+        self,
+        *,
+        seed: Optional[int] = None,
+        options: Dict[str, Optional[Dict[str, np.ndarray]]] = {
+            "initial_state_dict": None
+        },
+    ):
+        obs, info = super().reset(seed=seed)
+        if options["initial_state_dict"] is not None:
+            self.set_env_state(options["initial_state_dict"])
             obs = self._get_obs()
 
         return obs, info


### PR DESCRIPTION
# Description
Pass the `initial_state_dict` dictionary through the `options` argument in `reset()` in the `AdroitHand` environments. 

For good practice purposes `options` dictionary should be the default to specify any additional information that conditions how the environment is reset. https://gymnasium.farama.org/api/env/#gymnasium.Env.reset

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
