### PR TITLE
Update __init__.py

### DIFF
--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -57,13 +57,6 @@ def register_robotics_envs():
 
         register(
             id=f"FetchReach{suffix}-v2",
-            entry_point="gymnasium_robotics.envs.fetch.reach:MujocoPyFetchReachEnv",
-            kwargs=kwargs,
-            max_episode_steps=50,
-        )
-
-        register(
-            id=f"FetchReach{suffix}-v3",
             entry_point="gymnasium_robotics.envs.fetch.reach:MujocoFetchReachEnv",
             kwargs=kwargs,
             max_episode_steps=50,


### PR DESCRIPTION
Reptitive -v3 version for FetchReach

# Description

In the registered environments for Fetch, all environments had a v1 with mujoco_py bindings and v2 with mujoco bindings, except for the Fetch Reach environment which had v1 and v2 with mujoco_py bindings with a v3 for mujoco bindings. Removed v3 and replaced v2 with mujoco bindings to keep it consistent.

## Fixes 

Made Fetch Reach environment consistent with others.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
