### PR TITLE
Fix door state space key

### DIFF
--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -148,7 +148,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
 
     * `qpos`: np.ndarray with shape `(30,)`, MuJoCo simulation joint positions
     * `qvel`: np.ndarray with shape `(30,)`, MuJoCo simulation joint velocities
-    * `board_body_pos`: np.ndarray with shape `(3,)`, cartesian coordinates of the door body
+    * `door_body_pos`: np.ndarray with shape `(3,)`, cartesian coordinates of the door body
 
     The state of the simulation can also be set at any step with the `env.set_env_state(initial_state_dict)` method.
 


### PR DESCRIPTION
# Description

Change the incorrect key for the state space (Dictionary) of `AdroitHandDoor-v1`. Change `board_body_pos`  key for `door_body_pos`. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
