### PR TITLE
make getter functions for qpos / qvel return copies

### DIFF
--- a/gymnasium_robotics/utils/mujoco_utils.py
+++ b/gymnasium_robotics/utils/mujoco_utils.py
@@ -192,7 +192,7 @@ def get_joint_qpos(model, data, name):
     start_idx = joint_addr
     end_idx = joint_addr + ndim
 
-    return data.qpos[start_idx:end_idx]
+    return np.array(data.qpos[start_idx:end_idx])
 
 
 def get_joint_qvel(model, data, name):
@@ -212,7 +212,7 @@ def get_joint_qvel(model, data, name):
     start_idx = joint_addr
     end_idx = joint_addr + ndim
 
-    return data.qvel[start_idx:end_idx]
+    return np.array(data.qvel[start_idx:end_idx])
 
 
 def get_site_xpos(model, data, name):

--- a/gymnasium_robotics/utils/mujoco_utils.py
+++ b/gymnasium_robotics/utils/mujoco_utils.py
@@ -192,7 +192,7 @@ def get_joint_qpos(model, data, name):
     start_idx = joint_addr
     end_idx = joint_addr + ndim
 
-    return np.array(data.qpos[start_idx:end_idx])
+    return np.copy(data.qpos[start_idx:end_idx])
 
 
 def get_joint_qvel(model, data, name):
@@ -212,7 +212,7 @@ def get_joint_qvel(model, data, name):
     start_idx = joint_addr
     end_idx = joint_addr + ndim
 
-    return np.array(data.qvel[start_idx:end_idx])
+    return np.copy(data.qvel[start_idx:end_idx])
 
 
 def get_site_xpos(model, data, name):

--- a/gymnasium_robotics/utils/mujoco_utils.py
+++ b/gymnasium_robotics/utils/mujoco_utils.py
@@ -192,7 +192,7 @@ def get_joint_qpos(model, data, name):
     start_idx = joint_addr
     end_idx = joint_addr + ndim
 
-    return np.copy(data.qpos[start_idx:end_idx])
+    return data.qpos[start_idx:end_idx].copy()
 
 
 def get_joint_qvel(model, data, name):
@@ -212,7 +212,7 @@ def get_joint_qvel(model, data, name):
     start_idx = joint_addr
     end_idx = joint_addr + ndim
 
-    return np.copy(data.qvel[start_idx:end_idx])
+    return data.qvel[start_idx:end_idx].copy()
 
 
 def get_site_xpos(model, data, name):


### PR DESCRIPTION
# Description

Fixes #133 where getter functions for qpos / qvel return views instead of copies of the simulator data structure. If a user modifies these views, they will modify the simulator data as well, which is likely unintentional.

Note: I did not see a `CONTRIBUTING.md` in the main branch, so I was unable to do the checklist below. Please let me know how to proceed there.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
