### PR TITLE
set `PettingZoo` dependency to 1.22.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dynamic = ["version"]
 testing = [
 	"pytest==7.0.1",
 	"mujoco_py<2.2,>=2.1",
-        "PettingZoo>=1.22.2",
+        "PettingZoo>=1.22.3",
         "Jinja2>=3.0.3",
 ]
 mujoco_py = ["mujoco_py<2.2,>=2.1"]


### PR DESCRIPTION
# Description

Set PZ to 1.22.3

the API changes in 1.22.4 make it incompatible with `MaMuJoCo`
https://github.com/Farama-Foundation/PettingZoo/releases

I do not plan to port it to 1.22.4 (the release have been yanked)

I will port it to 1.22.5 once that comes out

