### PR TITLE
uncap `numpy` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "mujoco==2.3.3",
-    "numpy>=1.21.0,<1.24.0",
+    "numpy>=1.21.0",
     "gymnasium>=0.26",
     "PettingZoo>=1.23.0",
     "Jinja2>=3.0.3",


### PR DESCRIPTION
works fine with `numpy==1.24.3`