### PR TITLE
Fix CI for Gymnasium v0.29.0

### DIFF
--- a/gymnasium_robotics/envs/franka_kitchen/franka_env.py
+++ b/gymnasium_robotics/envs/franka_kitchen/franka_env.py
@@ -196,7 +196,7 @@ class FrankaRobot(MujocoEnv):
             )
             self.robot_pos_noise_amp[i] = read_config_from_node(
                 root, "qpos" + str(i), "pos_noise_amp", float
-            )
+            )[0]
             self.robot_vel_noise_amp[i] = read_config_from_node(
                 root, "qpos" + str(i), "vel_noise_amp", float
-            )
+            )[0]

--- a/gymnasium_robotics/envs/franka_kitchen/utils.py
+++ b/gymnasium_robotics/envs/franka_kitchen/utils.py
@@ -23,8 +23,8 @@ def read_config_from_node(root_node, parent_name, child_name, dtype=int):
 def get_config_root_node(config_file_name=None, config_file_data=None):
     # get root
     if config_file_data is None:
-        config_file_content = open(config_file_name)
-        config = ET.parse(config_file_content)
+        with open(config_file_name) as config_file_content:
+            config = ET.parse(config_file_content)
         root_node = config.getroot()
     else:
         root_node = ET.fromstring(config_file_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,11 @@ dynamic = ["version"]
 testing = [
 	"pytest==7.0.1",
 	"mujoco_py<2.2,>=2.1",
-        "PettingZoo>=1.23.0",
-        "Jinja2>=3.0.3",
+    "cython<3",
+    "PettingZoo>=1.23.0",
+    "Jinja2>=3.0.3",
 ]
-mujoco_py = ["mujoco_py<2.2,>=2.1"]
+mujoco_py = ["mujoco_py<2.2,>=2.1", "cython<3"]
 
 [project.urls]
 Homepage = "https://farama.org"


### PR DESCRIPTION
# Description

1. Fix CI issue with `mujoco_py` by specifying the `cython` version. Same issue as in Gymnasium, fixed in https://github.com/Farama-Foundation/Gymnasium/pull/616.
2. Close `franka_config.xml` after opening.
3. Fix Deprecation Warning from `numpy==1.25.0` in Franka environment

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
