### PR TITLE
Fix list index error when goal_cell and reset_cell are passed as options in PointMaze env

### DIFF
--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -218,7 +218,8 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["goal_cell"][1]
                 assert self.maze.map_width > options["goal_cell"][0]
                 assert (
-                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]] != 1
+                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]]
+                    != 1
                 ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
 
                 goal = self.maze.cell_rowcol_to_xy(options["goal_cell"])
@@ -233,7 +234,10 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["reset_cell"][1]
                 assert self.maze.map_width > options["reset_cell"][0]
                 assert (
-                    self.maze.maze_map[options["reset_cell"][1]][options["reset_cell"][0]] != 1
+                    self.maze.maze_map[options["reset_cell"][1]][
+                        options["reset_cell"][0]
+                    ]
+                    != 1
                 ), f"Reset can't be placed in a wall cell, {options['reset_cell']}"
 
                 reset_pos = self.maze.cell_rowcol_to_xy(options["reset_cell"])

--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -218,12 +218,10 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["goal_cell"][1]
                 assert self.maze.map_width > options["goal_cell"][0]
                 assert (
-                    self.maze.maze_map[options["goal_cell"][1], options["goal_cell"][0]]
-                    != 1
+                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]] != 1
                 ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
 
                 goal = self.maze.cell_rowcol_to_xy(options["goal_cell"])
-
             else:
                 goal = self.generate_target_goal()
 
@@ -235,10 +233,7 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["reset_cell"][1]
                 assert self.maze.map_width > options["reset_cell"][0]
                 assert (
-                    self.maze.maze_map[
-                        options["reset_cell"][1], options["reset_cell"][0]
-                    ]
-                    != 1
+                    self.maze.maze_map[options["reset_cell"][1]][options["reset_cell"][0]] != 1
                 ), f"Reset can't be placed in a wall cell, {options['reset_cell']}"
 
                 reset_pos = self.maze.cell_rowcol_to_xy(options["reset_cell"])

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -295,8 +295,9 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["goal_cell"][1]
                 assert self.maze.map_width > options["goal_cell"][0]
                 assert (
-                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]] != 1
-                    ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
+                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]]
+                    != 1
+                ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
 
                 goal = self.maze.cell_rowcol_to_xy(options["goal_cell"])
 
@@ -311,7 +312,10 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["reset_cell"][1]
                 assert self.maze.map_width > options["reset_cell"][0]
                 assert (
-                    self.maze.maze_map[options["reset_cell"][1]][options["reset_cell"][0]] != 1
+                    self.maze.maze_map[options["reset_cell"][1]][
+                        options["reset_cell"][0]
+                    ]
+                    != 1
                 ), f"Reset can't be placed in a wall cell, {options['reset_cell']}"
 
                 reset_pos = self.maze.cell_rowcol_to_xy(options["reset_cell"])

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -295,9 +295,8 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["goal_cell"][1]
                 assert self.maze.map_width > options["goal_cell"][0]
                 assert (
-                    self.maze.maze_map[options["goal_cell"][1], options["goal_cell"][0]]
-                    != 1
-                ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
+                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]] != 1
+                    ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
 
                 goal = self.maze.cell_rowcol_to_xy(options["goal_cell"])
 
@@ -312,10 +311,7 @@ class MazeEnv(GoalEnv):
                 assert self.maze.map_length > options["reset_cell"][1]
                 assert self.maze.map_width > options["reset_cell"][0]
                 assert (
-                    self.maze.maze_map[
-                        options["reset_cell"][1], options["reset_cell"][0]
-                    ]
-                    != 1
+                    self.maze.maze_map[options["reset_cell"][1]][options["reset_cell"][0]] != 1
                 ), f"Reset can't be placed in a wall cell, {options['reset_cell']}"
 
                 reset_pos = self.maze.cell_rowcol_to_xy(options["reset_cell"])

--- a/tests/envs/maze/test_point_maze.py
+++ b/tests/envs/maze/test_point_maze.py
@@ -11,3 +11,31 @@ def test_reset():
         assert not info["success"]
         dist = np.linalg.norm(obs["achieved_goal"] - obs["desired_goal"])
         assert dist > 0.45, f"dist={dist} < 0.45"
+
+
+def test_reset_cell():
+    """Check that passing the reset_cell location ensures that the agent resets in the right cell."""
+    map = [
+        [1, 1, 1, 1],
+        [1, "r", "r", 1],
+        [1, "r", "g", 1],
+        [1, 1, 1, 1],
+    ]
+    env = gym.make("PointMaze_UMaze-v3", maze_map=map)
+    obs = env.reset(options={"reset_cell": [1, 2]}, seed=42)[0]
+    desired_obs = np.array([0.67929896, 0.59868401, 0, 0])
+    np.testing.assert_almost_equal(desired_obs, obs["observation"], decimal=4)
+
+
+def test_goal_cell():
+    """Check that passing the goal_cell location ensures that the goal spawns in the right cell."""
+    map = [
+        [1, 1, 1, 1],
+        [1, "r", "g", 1],
+        [1, "g", "g", 1],
+        [1, 1, 1, 1],
+    ]
+    env = gym.make("PointMaze_UMaze-v3", maze_map=map)
+    obs = env.reset(options={"goal_cell": [2, 1]}, seed=42)[0]
+    desired_goal = np.array([-0.36302198, -0.53056078])
+    np.testing.assert_almost_equal(desired_goal, obs["desired_goal"], decimal=4)


### PR DESCRIPTION
# Description
This PR fixes an assertion error that arises when a specific `goal_cell` or `reset_cell` are passed as options in the `point_maze` env. 

Fixes #163 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots
<img width="820" alt="Screenshot 2023-08-01 at 9 05 11 PM" src="https://github.com/Farama-Foundation/Gymnasium-Robotics/assets/15188956/c36bf8bd-9282-433a-ad4a-de53e753f866">

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with
`pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
