### PR TITLE
Add  reset_target argument to antmaze environments

### DIFF
--- a/gymnasium_robotics/envs/maze/ant_maze_v4.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v4.py
@@ -183,7 +183,8 @@ class AntMazeEnv(MazeEnv, EzPickle):
     ### Arguments
 
     * `maze_map` - Optional argument to initialize the environment with a custom maze map.
-    * `continuing_task` - If set to `True` the episode won't be terminated when reaching the goal, instead a new goal location will be generated. If `False` the environment is terminated when the ant reaches the final goal.
+    * `continuing_task` - If set to `True` the episode won't be terminated when reaching the goal, instead a new goal location will be generated (unless `reset_target` argument is `True`). If `False` the environment is terminated when the ant reaches the final goal.
+    * `reset_target` - If set to `True` and the argument `continuing_task` is also `True`, when the ant reaches the target goal the location of the goal will be kept the same and no new goal location will be generated. If `False` a new goal will be generated when reached.
     * `use_contact_forces` - If `True` contact forces of the ant are included in the `observation`.
 
     Note that, the maximum number of timesteps before the episode is `truncated` can be increased or decreased by specifying the `max_episode_steps` argument at initialization. For example,

--- a/gymnasium_robotics/envs/maze/ant_maze_v4.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v4.py
@@ -230,6 +230,7 @@ class AntMazeEnv(MazeEnv, EzPickle):
             maze_height=0.5,
             reward_type=reward_type,
             continuing_task=continuing_task,
+            reset_target=reset_target,
             **kwargs,
         )
         # Create the MuJoCo environment, include position observation of the Ant for GoalEnv

--- a/gymnasium_robotics/envs/maze/ant_maze_v4.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v4.py
@@ -216,6 +216,7 @@ class AntMazeEnv(MazeEnv, EzPickle):
         maze_map: List[List[Union[str, int]]] = U_MAZE,
         reward_type: str = "sparse",
         continuing_task: bool = True,
+        reset_target: bool = True,
         **kwargs,
     ):
         # Get the ant.xml path from the Gymnasium package

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -238,6 +238,7 @@ class MazeEnv(GoalEnv):
         agent_xml_path: str,
         reward_type: str = "dense",
         continuing_task: bool = True,
+        reset_target: bool = True,
         maze_map: List[List[Union[int, str]]] = U_MAZE,
         maze_size_scaling: float = 1.0,
         maze_height: float = 0.5,
@@ -247,6 +248,7 @@ class MazeEnv(GoalEnv):
 
         self.reward_type = reward_type
         self.continuing_task = continuing_task
+        self.reset_target = reset_target
         self.maze, self.tmp_xml_file_path = Maze.make_maze(
             agent_xml_path, maze_map, maze_size_scaling, maze_height
         )
@@ -375,6 +377,7 @@ class MazeEnv(GoalEnv):
         """Update goal position if continuing task and within goal radius."""
         if (
             self.continuing_task
+            and self.reset_target
             and bool(np.linalg.norm(achieved_goal - self.goal) <= 0.45)
             and len(self.maze.unique_goal_locations) > 1
         ):

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -279,6 +279,7 @@ class PointMazeEnv(MazeEnv, EzPickle):
 
     * `maze_map` - Optional argument to initialize the environment with a custom maze map.
     * `continuing_task` - If set to `True` the episode won't be terminated when reaching the goal, instead a new goal location will be generated. If `False` the environment is terminated when the ball reaches the final goal.
+    * `reset_target` - If set to `True` and the argument `continuing_task` is also `True`, when the ant reaches the target goal the location of the goal will be kept the same and no new goal location will be generated. If `False` a new goal will be generated when reached.
 
     Note that, the maximum number of timesteps before the episode is `truncated` can be increased or decreased by specifying the `max_episode_steps` argument at initialization. For example,
     to increase the total number of timesteps to 100 make the environment as follows:

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -309,6 +309,7 @@ class PointMazeEnv(MazeEnv, EzPickle):
         render_mode: Optional[str] = None,
         reward_type: str = "sparse",
         continuing_task: bool = True,
+        reset_target: bool = False,
         **kwargs,
     ):
         point_xml_file_path = path.join(
@@ -321,6 +322,7 @@ class PointMazeEnv(MazeEnv, EzPickle):
             maze_height=0.4,
             reward_type=reward_type,
             continuing_task=continuing_task,
+            reset_target=reset_target,
             **kwargs,
         )
 


### PR DESCRIPTION
# Description

This PR adds the `reset_target` boolean argument to v4 antmaze environments. If this argument is set to `True` and `continuing_task` is also `True`, the goal won't be re-generated to another location when reached by the agent. If `False` and `continuing_task` still  equals `True`, then another goal location will be generated instead of terminating/truncating the episode when the ant reaches a goal.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
