### PR TITLE
Update Maze environments

### DIFF
--- a/gymnasium_robotics/envs/maze/ant_maze_v4.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v4.py
@@ -258,13 +258,13 @@ class AntMazeEnv(MazeEnv, EzPickle):
         )
 
         self.render_mode = render_mode
-
         EzPickle.__init__(
             self,
             render_mode,
             maze_map,
             reward_type,
             continuing_task,
+            reset_target,
             **kwargs,
         )
 

--- a/gymnasium_robotics/envs/maze/ant_maze_v4.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v4.py
@@ -217,7 +217,7 @@ class AntMazeEnv(MazeEnv, EzPickle):
         maze_map: List[List[Union[str, int]]] = U_MAZE,
         reward_type: str = "sparse",
         continuing_task: bool = True,
-        reset_target: bool = True,
+        reset_target: bool = False,
         **kwargs,
     ):
         # Get the ant.xml path from the Gymnasium package

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -221,6 +221,15 @@ class Maze:
             # If there are no given "r", "g" or "c" cells in the maze data structure,
             # any empty cell can be a reset or goal location at initialization.
             maze._combined_locations = empty_locations
+        elif not maze._unique_reset_locations and not maze._combined_locations:
+            # If there are no given "r" or "c" cells in the maze data structure,
+            # any empty cell can be a reset location at initialization.
+            maze._unique_reset_locations = empty_locations
+        elif not maze._unique_goal_locations and not maze._combined_locations:
+            # If there are no given "g" or "c" cells in the maze data structure,
+            # any empty cell can be a gaol location at initialization.
+            maze._unique_goal_locations = empty_locations
+
         maze._unique_goal_locations += maze._combined_locations
         maze._unique_reset_locations += maze._combined_locations
 

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -375,6 +375,7 @@ class MazeEnv(GoalEnv):
 
     def update_goal(self, achieved_goal: np.ndarray) -> None:
         """Update goal position if continuing task and within goal radius."""
+
         if (
             self.continuing_task
             and self.reset_target

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -310,7 +310,7 @@ class PointMazeEnv(MazeEnv, EzPickle):
         render_mode: Optional[str] = None,
         reward_type: str = "sparse",
         continuing_task: bool = True,
-        reset_target: bool = False,
+        reset_target: bool = True,
         **kwargs,
     ):
         point_xml_file_path = path.join(
@@ -359,6 +359,7 @@ class PointMazeEnv(MazeEnv, EzPickle):
             render_mode,
             reward_type,
             continuing_task,
+            reset_target,
             **kwargs,
         )
 

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -310,7 +310,7 @@ class PointMazeEnv(MazeEnv, EzPickle):
         render_mode: Optional[str] = None,
         reward_type: str = "sparse",
         continuing_task: bool = True,
-        reset_target: bool = True,
+        reset_target: bool = False,
         **kwargs,
     ):
         point_xml_file_path = path.join(


### PR DESCRIPTION
# Description

This PR makes the following updates to the maze environments (`pointmaze` and `antmaze`):
- Default `reset_target` to `False`.
- When there are no goals ("g") or reset ("r") cells provided in the `maze_map` structure, the environment will select these cells at random from the empty cells ("0") when reset. 
- Allow serialization of the `reset_target` argument with EzPickle

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
