### PR TITLE
Fix gen_envs_display.py in docs 

### DIFF
--- a/docs/_scripts/gen_envs_display.py
+++ b/docs/_scripts/gen_envs_display.py
@@ -1,5 +1,6 @@
 import os
 import re
+
 import gymnasium as gym
 from tqdm import tqdm
 

--- a/docs/_scripts/gen_envs_display.py
+++ b/docs/_scripts/gen_envs_display.py
@@ -1,5 +1,5 @@
 import os
-
+import re
 import gymnasium as gym
 from tqdm import tqdm
 
@@ -30,6 +30,9 @@ if __name__ == "__main__":
         if len(split_entrypoint) == 3:
             env_type = split_entrypoint[-1]
             env_name = split_entrypoint[-1]
+
+        # Remove file version from env_name
+        env_name = re.sub(r"(?:_v(?P<version>\d+))", "", env_name)
 
         if env_type not in filtered_envs_by_type:
             filtered_envs_by_type[env_type] = [env_name]


### PR DESCRIPTION
# Description

Remove versioning from file names.

Removes the display in the middle from the docs:

![image](https://github.com/Farama-Foundation/Gymnasium-Robotics/assets/60633730/c94deb9d-11c3-46d6-8cc9-270a2c9fd195)


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
