### PR TITLE
[Bug Fix] Correct assertions in Maze environment reset

### DIFF
--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -215,10 +215,10 @@ class MazeEnv(GoalEnv):
         else:
             if "goal_cell" in options and options["goal_cell"] is not None:
                 # assert that goal cell is valid
-                assert self.maze.map_length > options["goal_cell"][1]
-                assert self.maze.map_width > options["goal_cell"][0]
+                assert self.maze.map_length > options["goal_cell"][0]
+                assert self.maze.map_width > options["goal_cell"][1]
                 assert (
-                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]]
+                    self.maze.maze_map[options["goal_cell"][0]][options["goal_cell"][1]]
                     != 1
                 ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
 
@@ -231,11 +231,11 @@ class MazeEnv(GoalEnv):
 
             if "reset_cell" in options and options["reset_cell"] is not None:
                 # assert that goal cell is valid
-                assert self.maze.map_length > options["reset_cell"][1]
-                assert self.maze.map_width > options["reset_cell"][0]
+                assert self.maze.map_length > options["reset_cell"][0]
+                assert self.maze.map_width > options["reset_cell"][1]
                 assert (
-                    self.maze.maze_map[options["reset_cell"][1]][
-                        options["reset_cell"][0]
+                    self.maze.maze_map[options["reset_cell"][0]][
+                        options["reset_cell"][1]
                     ]
                     != 1
                 ), f"Reset can't be placed in a wall cell, {options['reset_cell']}"

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -293,6 +293,12 @@ class MazeEnv(GoalEnv):
         seed: Optional[int] = None,
         options: Optional[Dict[str, Optional[np.ndarray]]] = None,
     ):
+        """Reset the maze simulation.
+
+        Args:
+            options (dict[str, np.ndarray]): the options dictionary can contain two items, "goal_cell" and "reset_cell" that will set the initial goal and reset location (i,j) in the self.maze.map list of list maze structure.
+
+        """
         super().reset(seed=seed)
 
         if options is None:
@@ -303,10 +309,10 @@ class MazeEnv(GoalEnv):
         else:
             if "goal_cell" in options and options["goal_cell"] is not None:
                 # assert that goal cell is valid
-                assert self.maze.map_length > options["goal_cell"][1]
-                assert self.maze.map_width > options["goal_cell"][0]
+                assert self.maze.map_length > options["goal_cell"][0]
+                assert self.maze.map_width > options["goal_cell"][1]
                 assert (
-                    self.maze.maze_map[options["goal_cell"][1]][options["goal_cell"][0]]
+                    self.maze.maze_map[options["goal_cell"][0]][options["goal_cell"][1]]
                     != 1
                 ), f"Goal can't be placed in a wall cell, {options['goal_cell']}"
 
@@ -320,11 +326,11 @@ class MazeEnv(GoalEnv):
 
             if "reset_cell" in options and options["reset_cell"] is not None:
                 # assert that goal cell is valid
-                assert self.maze.map_length > options["reset_cell"][1]
-                assert self.maze.map_width > options["reset_cell"][0]
+                assert self.maze.map_length > options["reset_cell"][0]
+                assert self.maze.map_width > options["reset_cell"][1]
                 assert (
-                    self.maze.maze_map[options["reset_cell"][1]][
-                        options["reset_cell"][0]
+                    self.maze.maze_map[options["reset_cell"][0]][
+                        options["reset_cell"][1]
                     ]
                     != 1
                 ), f"Reset can't be placed in a wall cell, {options['reset_cell']}"


### PR DESCRIPTION
# Description
This PR fixes the comment in this previous PR https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/163#issuecomment-1675839059

The elements of "goal_cell" and "reset_cell" need to be inverted for the assertions since they represent the `(i,j)` cell in the maze map list of lists structure as specified in the [docs](https://robotics.farama.org/envs/maze/point_maze/#starting-state).

The changes are made in both `maze.py` and `maze_v4.py`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
