### PR TITLE
Change XML saving for maze to fix infrequent crash

### DIFF
--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -12,7 +12,6 @@ This project is covered by the Apache 2.0 License.
 """
 import math
 import tempfile
-import time
 import xml.etree.ElementTree as ET
 from os import path
 from typing import Dict, List, Optional, Union

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -53,7 +53,6 @@ class Maze:
         maze_size_scaling: float,
         maze_height: float,
     ):
-
         self._maze_map = maze_map
         self._maze_size_scaling = maze_size_scaling
         self._maze_height = maze_height
@@ -235,12 +234,13 @@ class Maze:
         maze._unique_reset_locations += maze._combined_locations
 
         # Save new xml with maze to a temporary file
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            temp_xml_name = f"ant_maze{str(time.time())}.xml"
-            temp_xml_path = path.join(path.dirname(tmp_dir), temp_xml_name)
-            tree.write(temp_xml_path)
+        tmp_dir = tempfile.TemporaryDirectory()
+        temp_xml_path = path.join(tmp_dir.name, "ant_maze.xml")
 
-        return maze, temp_xml_path
+        with open(temp_xml_path, "wb") as xml_file:
+            tree.write(xml_file)
+
+        return maze, temp_xml_path, tmp_dir
 
 
 class MazeEnv(GoalEnv):
@@ -256,11 +256,10 @@ class MazeEnv(GoalEnv):
         position_noise_range: float = 0.25,
         **kwargs,
     ):
-
         self.reward_type = reward_type
         self.continuing_task = continuing_task
         self.reset_target = reset_target
-        self.maze, self.tmp_xml_file_path = Maze.make_maze(
+        self.maze, self.tmp_xml_file_path, self.tmp_dir = Maze.make_maze(
             agent_xml_path, maze_map, maze_size_scaling, maze_height
         )
 

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -423,3 +423,7 @@ class MazeEnv(GoalEnv):
         """Override this method to update the site qpos in the MuJoCo simulation
         after a new goal is selected. This is mainly for visualization purposes."""
         raise NotImplementedError
+    
+    def __del__(self):
+        self.tmp_dir.cleanup()
+        super().__del__()

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -233,13 +233,19 @@ class Maze:
         maze._unique_reset_locations += maze._combined_locations
 
         # Save new xml with maze to a temporary file
+        # Make temporary file object and make the string path to our new file
         tmp_dir = tempfile.TemporaryDirectory()
         temp_xml_path = path.join(tmp_dir.name, "ant_maze.xml")
 
+        # Write the new xml to the temporary file
         with open(temp_xml_path, "wb") as xml_file:
             tree.write(xml_file)
 
-        return maze, temp_xml_path, tmp_dir
+        return (
+            maze,
+            temp_xml_path,
+            tmp_dir,  # The tmp_dir object is returned to keep it alive
+        )
 
 
 class MazeEnv(GoalEnv):


### PR DESCRIPTION
# Description

I changed the way that temporary xmls are stored for the maze envs. I have used this change for training and it improves stability, without it my training would crash sometimes, usually after about 1m env steps. With this change it seems to be stable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes