### PR TITLE
pin `pyright==1.1.347` (match gymnasium)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ["pyright"]
+        additional_dependencies: ["pyright@1.1.347"]
         args:
           - --project=pyproject.toml
   - repo: https://github.com/pycqa/pydocstyle


### PR DESCRIPTION
From now on, since `gymnasium` pins `pyright,` we shall follow so 