### PR TITLE
Updated Dense Reward for Maze tasks

### DIFF
--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -274,9 +274,9 @@ class MazeEnv(GoalEnv):
     def compute_reward(
         self, achieved_goal: np.ndarray, desired_goal: np.ndarray, info
     ) -> float:
-        distance = np.linalg.norm(achieved_goal - desired_goal, axis=-1)
+        distance = np.linalg.norm(achieved_goal - desired_goal, ord = 2, axis=-1)
         if self.reward_type == "dense":
-            return np.exp(-distance)
+            return -distance
         elif self.reward_type == "sparse":
             return (distance <= 0.45).astype(np.float64)
 

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -374,9 +374,9 @@ class MazeEnv(GoalEnv):
     def compute_reward(
         self, achieved_goal: np.ndarray, desired_goal: np.ndarray, info
     ) -> float:
-        distance = np.linalg.norm(achieved_goal - desired_goal, axis=-1)
+        distance = np.linalg.norm(achieved_goal - desired_goal, ord = 2, axis=-1)
         if self.reward_type == "dense":
-            return np.exp(-distance)
+            return -distance
         elif self.reward_type == "sparse":
             return (distance <= 0.45).astype(np.float64)
 


### PR DESCRIPTION
# Description

Updated the dense reward of Maze environments from exp(-distance) to -distance

Fixes #175 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Please attach before and after screenshots of the change if applicable.

![image](https://github.com/Farama-Foundation/Gymnasium-Robotics/assets/50509572/c2bc0606-8747-4a3e-b8be-214d4554ed79)


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
