### PR TITLE
Adroit hand dense reward fixes

### DIFF
--- a/gymnasium_robotics/envs/adroit_hand/adroit_door.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_door.py
@@ -294,7 +294,7 @@ class AdroitHandDoorEnv(MujocoEnv, EzPickle):
             palm_pos = self.data.site_xpos[self.grasp_site_id].ravel()
 
             # get to handle
-            reward = 0.1 * np.linalg.norm(palm_pos - handle_pos)
+            reward = -0.1 * np.linalg.norm(palm_pos - handle_pos)
             # open door
             reward += -0.1 * (goal_distance - 1.57) * (goal_distance - 1.57)
             # velocity cost

--- a/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_hammer.py
@@ -305,7 +305,7 @@ class AdroitHandHammerEnv(MujocoEnv, EzPickle):
         # override reward if not sparse reward
         if not self.sparse_reward:
             # get the palm to the hammer handle
-            reward = 0.1 * np.linalg.norm(palm_pos - hamm_pos)
+            reward = -0.1 * np.linalg.norm(palm_pos - hamm_pos)
             # take hammer head to nail
             reward -= np.linalg.norm(head_pos - nail_pos)
             # make nail go inside

--- a/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
+++ b/gymnasium_robotics/envs/adroit_hand/adroit_relocate.py
@@ -294,7 +294,7 @@ class AdroitHandRelocateEnv(MujocoEnv, EzPickle):
 
         # override reward if not sparse reward
         if not self.sparse_reward:
-            reward = 0.1 * np.linalg.norm(palm_pos - obj_pos)  # take hand to object
+            reward = -0.1 * np.linalg.norm(palm_pos - obj_pos)  # take hand to object
             if obj_pos[2] > 0.04:  # if object off the table
                 reward += 1.0  # bonus for lifting the object
                 reward += -0.5 * np.linalg.norm(


### PR DESCRIPTION
* fix hand-to-object dense reward component sign in adroit hand door, hammer, and relocate scenarios

# Description

This PR fixes the hand-to-object dense reward component signs in the adroit hand door, hammer, and relocate scenarios.

The bugs cause the agent to maximize distance between the hand and the object of interest.

The bugs were introduced in 7b5aa90 with a refactor of the relevant code sections. I ran trainings before and after the fix to confirm that it works.

As far as I can tell the pen scenario is not affected, so no changes there.

I couldn't find the relevant CONTRIBUTING.md file to set stuff up for precommit and unit testing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes