### PR TITLE
Fix rendering bug by setting frame height and width

### DIFF
--- a/gymnasium_robotics/envs/robot_env.py
+++ b/gymnasium_robotics/envs/robot_env.py
@@ -282,7 +282,11 @@ class MujocoRobotEnv(BaseRobotEnv):
         from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer
 
         self.mujoco_renderer = MujocoRenderer(
-            self.model, self.data, default_camera_config
+            self.model,
+            self.data,
+            default_camera_config,
+            width=self.width,
+            height=self.height,
         )
 
     def _initialize_simulation(self):


### PR DESCRIPTION
# Description

Gymnasium 1.0.0 added the width and height parameters to the initialization method of the `MujocoRenderer` class. If no values are passed in, they default to None and this causes rendering to fail when the `render_mode` is set to `rgb_array` (at least for onscreen rendering). This fix passes the height and width parameters in the `BaseRobotEnv` class to the `MujocoRenderer` in `robot_env.py`, resolving the issue. 

Fixes #235 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes