### PR TITLE
Fix bugs in kettle_asset.xml to ensure compatibility with the latest MuJoCo versions

### DIFF
--- a/gymnasium_robotics/envs/assets/kitchen_franka/kitchen_assets/item_assets/kettle_asset.xml
+++ b/gymnasium_robotics/envs/assets/kitchen_franka/kitchen_assets/item_assets/kettle_asset.xml
@@ -13,11 +13,13 @@
         <material name="kettle_white" rgba=".9 .9 .9 1" reflectance="1" shininess="1" />
         <material name="kettle_collision_blue" rgba="0.3 0.3 1.0 0.5" shininess="0" specular="0" />
     </asset>
-    <default class="kettle">
-        <joint damping="2" frictionloss="2" armature=".01" limited="true" />
-        <geom conaffinity="0" contype="0" group="1" material="kettle_white" type="mesh"/>
-        <default class="kettle_collision">
-            <geom conaffinity="1" condim="4" contype="1" group="4" margin="0.001" material="kettle_collision_blue" solimp=".8 .9 .01" solref=".02 1" type="mesh"/>
+    <default>
+        <default class="kettle">
+            <joint damping="2" frictionloss="2" armature=".01" limited="true" />
+            <geom conaffinity="0" contype="0" group="1" material="kettle_white" type="mesh"/>
+            <default class="kettle_collision">
+                <geom conaffinity="1" condim="4" contype="1" group="4" margin="0.001" material="kettle_collision_blue" solimp=".8 .9 .01" solref=".02 1" type="mesh"/>
+            </default>
         </default>
     </default>
 </mujocoinclude>


### PR DESCRIPTION
# Description

There's a missing <default> tag in kettle_asset.xml. This will bring errors in the latest version of MuJoCo (>3.16). I have validated that this change does not change the behavior of the environment for older versions of mujoco (3.1.6, 3.0.1). However, the behavior in MuJoCo version (<3.0, e.g. 2.1.5) remains to be checked (if needed).

Related issues $ temp fixes includes: 
https://github.com/Farama-Foundation/D4RL/issues/236#issue-2420593982
https://github.com/CleanDiffuserTeam/CleanDiffuser/pull/24
https://github.com/Farama-Foundation/D4RL/pull/238#issue-2600047899


## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Notes
This behavior aligns with other assets descriptions in kitchen. For example, in microwave:
```xml
    <default>
        <default class="microwave">
            <joint damping="2" frictionloss="2" armature=".01" limited="true"/>
            <geom conaffinity="0" contype="0" group="1" material="micro_black" type="mesh"/>
            <default class="micro_collision">
                <geom conaffinity="1" condim="3" contype="0" group="4" margin="0.001" material="micro_collision_blue" solimp=".8 .9 .01" solref=".02 1"/>
            </default>
        </default>
    </default>
```
in oven:
```xml
    <default>
        <default class="oven">
            <joint armature="0.001" damping="2" limited="true"/>
            <geom conaffinity="0" contype="0" group="1" material="oven_metal" type="mesh"/>
            <default class="ovenlight" >
                <light directional="false" castshadow="true" attenuation="0.03 0.03 0.03" cutoff="100" exponent="25" diffuse=".7 .65 .65" specular=".3 .3 .3"/>
            </default>
            <default class="oven_collision">
                <geom conaffinity="1" condim="3" contype="0" group="4" margin="0.001" material="oven_collision_blue" type="mesh"/>
            </default>
        </default>
    </default>
```
However, in kettle
```xml
    <default class="kettle">
        <joint damping="2" frictionloss="2" armature=".01" limited="true" />
        <geom conaffinity="0" contype="0" group="1" material="kettle_white" type="mesh"/>
        <default class="kettle_collision">
            <geom conaffinity="1" condim="4" contype="1" group="4" margin="0.001" material="kettle_collision_blue" solimp=".8 .9 .01" solref=".02 1" type="mesh"/>
        </default>
    </default>
```

I hope this typo could be fixed soon. Since in latest version of MuJoCo, the default tag without name is identified as "main default", which will bring errors like:
```shell
ValueError: XML Error: top-level default class 'main' cannot be renamed
```


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
