### PR TITLE
Fixes Fetch and Robotic environments initial state issues in 1.3.0

### DIFF
--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -30,7 +30,7 @@ def register_robotics_envs():
         )
 
         register(
-            id=f"FetchSlide{suffix}-v3",
+            id=f"FetchSlide{suffix}-v4",
             entry_point="gymnasium_robotics.envs.fetch.slide:MujocoFetchSlideEnv",
             kwargs=kwargs,
             max_episode_steps=50,
@@ -44,7 +44,7 @@ def register_robotics_envs():
         )
 
         register(
-            id=f"FetchPickAndPlace{suffix}-v3",
+            id=f"FetchPickAndPlace{suffix}-v4",
             entry_point="gymnasium_robotics.envs.fetch.pick_and_place:MujocoFetchPickAndPlaceEnv",
             kwargs=kwargs,
             max_episode_steps=50,
@@ -58,7 +58,7 @@ def register_robotics_envs():
         )
 
         register(
-            id=f"FetchReach{suffix}-v3",
+            id=f"FetchReach{suffix}-v4",
             entry_point="gymnasium_robotics.envs.fetch.reach:MujocoFetchReachEnv",
             kwargs=kwargs,
             max_episode_steps=50,
@@ -72,7 +72,7 @@ def register_robotics_envs():
         )
 
         register(
-            id=f"FetchPush{suffix}-v3",
+            id=f"FetchPush{suffix}-v4",
             entry_point="gymnasium_robotics.envs.fetch.push:MujocoFetchPushEnv",
             kwargs=kwargs,
             max_episode_steps=50,
@@ -87,7 +87,7 @@ def register_robotics_envs():
         )
 
         register(
-            id=f"HandReach{suffix}-v2",
+            id=f"HandReach{suffix}-v3",
             entry_point="gymnasium_robotics.envs.shadow_dexterous_hand.reach:MujocoHandReachEnv",
             kwargs=kwargs,
             max_episode_steps=50,

--- a/gymnasium_robotics/envs/fetch/fetch_env.py
+++ b/gymnasium_robotics/envs/fetch/fetch_env.py
@@ -376,6 +376,12 @@ class MujocoFetchEnv(get_base_fetch_env(MujocoRobotEnv)):
         # Reset buffers for joint states, actuators, warm-start, control buffers etc.
         self._mujoco.mj_resetData(self.model, self.data)
 
+        self.data.time = self.initial_time
+        self.data.qpos[:] = np.copy(self.initial_qpos)
+        self.data.qvel[:] = np.copy(self.initial_qvel)
+        if self.model.na != 0:
+            self.data.act[:] = None
+
         # Randomize start position of object.
         if self.has_object:
             object_xpos = self.initial_gripper_xpos[:2]

--- a/gymnasium_robotics/envs/fetch/pick_and_place.py
+++ b/gymnasium_robotics/envs/fetch/pick_and_place.py
@@ -130,6 +130,7 @@ class MujocoFetchPickAndPlaceEnv(MujocoFetchEnv, EzPickle):
 
     ## Version History
 
+    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/fetch/pick_and_place.py
+++ b/gymnasium_robotics/envs/fetch/pick_and_place.py
@@ -130,7 +130,7 @@ class MujocoFetchPickAndPlaceEnv(MujocoFetchEnv, EzPickle):
 
     ## Version History
 
-    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
+    * v4: Fixed bug where initial state did not match initial state description in documentation. Fetch environments' initial states after reset now match the documentation (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251)).
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/fetch/push.py
+++ b/gymnasium_robotics/envs/fetch/push.py
@@ -157,6 +157,8 @@ class MujocoFetchPushEnv(MujocoFetchEnv, EzPickle):
     ```
 
     ## Version History
+    
+    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/fetch/push.py
+++ b/gymnasium_robotics/envs/fetch/push.py
@@ -157,8 +157,8 @@ class MujocoFetchPushEnv(MujocoFetchEnv, EzPickle):
     ```
 
     ## Version History
-    
-    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
+
+    * v4: Fixed bug where initial state did not match initial state description in documentation. Fetch environments' initial states after reset now match the documentation (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251)).
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/fetch/reach.py
+++ b/gymnasium_robotics/envs/fetch/reach.py
@@ -115,8 +115,8 @@ class MujocoFetchReachEnv(MujocoFetchEnv, EzPickle):
     ```
 
     ## Version History
-    
-    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
+
+    * v4: Fixed bug where initial state did not match initial state description in documentation. Fetch environments' initial states after reset now match the documentation (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251)).
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/fetch/reach.py
+++ b/gymnasium_robotics/envs/fetch/reach.py
@@ -115,6 +115,8 @@ class MujocoFetchReachEnv(MujocoFetchEnv, EzPickle):
     ```
 
     ## Version History
+    
+    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/fetch/slide.py
+++ b/gymnasium_robotics/envs/fetch/slide.py
@@ -156,8 +156,8 @@ class MujocoFetchSlideEnv(MujocoFetchEnv, EzPickle):
     ```
 
     ## Version History
-    
-    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
+
+    * v4: Fixed bug where initial state did not match initial state description in documentation. Fetch environments' initial states after reset now match the documentation (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251)).
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/fetch/slide.py
+++ b/gymnasium_robotics/envs/fetch/slide.py
@@ -156,6 +156,8 @@ class MujocoFetchSlideEnv(MujocoFetchEnv, EzPickle):
     ```
 
     ## Version History
+    
+    * v4: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
     * v3: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v2: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v1: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/robot_env.py
+++ b/gymnasium_robotics/envs/robot_env.py
@@ -305,6 +305,14 @@ class MujocoRobotEnv(BaseRobotEnv):
     def _reset_sim(self):
         # Reset buffers for joint states, warm-start, control buffers etc.
         mujoco.mj_resetData(self.model, self.data)
+
+        self.data.time = self.initial_time
+        self.data.qpos[:] = np.copy(self.initial_qpos)
+        self.data.qvel[:] = np.copy(self.initial_qvel)
+        if self.model.na != 0:
+            self.data.act[:] = None
+
+        self._mujoco.mj_forward(self.model, self.data)
         return super()._reset_sim()
 
     def render(self):

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
@@ -387,6 +387,7 @@ class MujocoHandReachEnv(get_base_hand_reanch_env(MujocoHandEnv)):
     ```
 
     ## Version History
+    * v3: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
     * v2: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v1: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v0: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
@@ -387,7 +387,8 @@ class MujocoHandReachEnv(get_base_hand_reanch_env(MujocoHandEnv)):
     ```
 
     ## Version History
-    * v3: Fixed bug: the initial state not matching the initial state description in the documentation. Hand Reach environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
+
+    * v3: Fixed bug where initial state did not match initial state description in documentation. Hand Reach environments' initial states after reset now match the documentation (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251)).
     * v2: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v1: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v0: the environment depends on `mujoco_py` which is no longer maintained.

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
@@ -387,7 +387,7 @@ class MujocoHandReachEnv(get_base_hand_reanch_env(MujocoHandEnv)):
     ```
 
     ## Version History
-    * v3: Fixed bug: the initial state not matching the initial state description in the documentation. Fetch environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
+    * v3: Fixed bug: the initial state not matching the initial state description in the documentation. Hand Reach environments' initial states after reset now align with the documentation.(related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/251))
     * v2: Fixed bug: `env.reset()` not properly resetting the internal state. Fetch environments now properly reset their state (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207)).
     * v1: the environment depends on the newest [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html) maintained by the MuJoCo team in Deepmind.
     * v0: the environment depends on `mujoco_py` which is no longer maintained.

--- a/tests/envs/hand/test_reach.py
+++ b/tests/envs/hand/test_reach.py
@@ -8,7 +8,7 @@ gym.register_envs(gymnasium_robotics)
 
 
 def test_serialize_deserialize():
-    env1 = gym.make("HandReach-v2", distance_threshold=1e-6)
+    env1 = gym.make("HandReach-v3", distance_threshold=1e-6)
     env1.reset()
     env2 = pickle.loads(pickle.dumps(env1))
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,9 +1,8 @@
 import pickle
 import warnings
 
-import numpy as np
-
 import gymnasium as gym
+import numpy as np
 import pytest
 from gymnasium.envs.mujoco.utils import check_mujoco_reset_state
 from gymnasium.envs.registration import EnvSpec
@@ -166,43 +165,64 @@ def test_pickle_env(env_spec):
     env.close()
     pickled_env.close()
 
-_test_robot_env_reset_list = ['Fetch', 'HandReach']
+
+_test_robot_env_reset_list = ["Fetch", "HandReach"]
+
 
 @pytest.mark.parametrize(
-    "spec", 
-    [spec for spec in non_mujoco_py_env_specs if np.any([tar in spec.id for tar in _test_robot_env_reset_list])], 
-    ids=[spec.id for spec in non_mujoco_py_env_specs if np.any([tar in spec.id for tar in _test_robot_env_reset_list])]
+    "spec",
+    [
+        spec
+        for spec in non_mujoco_py_env_specs
+        if np.any([tar in spec.id for tar in _test_robot_env_reset_list])
+    ],
+    ids=[
+        spec.id
+        for spec in non_mujoco_py_env_specs
+        if np.any([tar in spec.id for tar in _test_robot_env_reset_list])
+    ],
 )
 def test_robot_env_reset(spec):
-    """Checks initial state of robotic environment, i.e. Fetch and Shadow Dexterous Hand Reach, 
-    whether their initial states align with the document."""
+    """Check initial state of robotic environment, i.e. Fetch and Shadow Dexterous Hand Reach,
+    whether their initial states match the description in the documentation."""
 
     def _test_initial_states(env, seed=None):
         diag_dict = {}
 
-        init_obs = env.reset(seed = seed)
+        init_obs = env.reset(seed=seed)
 
         if isinstance(init_obs[0], dict):
             diag_dict.update(**init_obs[0])
         elif isinstance(init_obs[0], np.ndarray):
-            diag_dict.update({'observation': init_obs[0]})
-        diag_dict.update({
-            'qpos': env.unwrapped.data.qpos,
-            'qvel': env.unwrapped.data.qvel,
-            'init_qpos': env.unwrapped.initial_qpos,
-            'init_qvel': env.unwrapped.initial_qvel
-        })
+            diag_dict.update({"observation": init_obs[0]})
+        diag_dict.update(
+            {
+                "qpos": env.unwrapped.data.qpos,
+                "qvel": env.unwrapped.data.qvel,
+                "init_qpos": env.unwrapped.initial_qpos,
+                "init_qvel": env.unwrapped.initial_qvel,
+            }
+        )
 
         # exclude object location from environments
-        if np.any([tar in spec.id for tar in ['FetchPush', 'FetchPickAndPlace', 'FetchSlide',]]):
-            diag_dict['qpos'] = np.delete(diag_dict['qpos'], np.s_[-7:-5])
-            diag_dict['init_qpos'] = np.delete(diag_dict['init_qpos'], np.s_[-7:-5])
+        if np.any(
+            [
+                tar in spec.id
+                for tar in [
+                    "FetchPush",
+                    "FetchPickAndPlace",
+                    "FetchSlide",
+                ]
+            ]
+        ):
+            diag_dict["qpos"] = np.delete(diag_dict["qpos"], np.s_[-7:-5])
+            diag_dict["init_qpos"] = np.delete(diag_dict["init_qpos"], np.s_[-7:-5])
 
         # testing
-        assert np.allclose(diag_dict['qpos'], diag_dict['init_qpos'])
-        assert np.allclose(diag_dict['qvel'], diag_dict['init_qvel'])
+        assert np.allclose(diag_dict["qpos"], diag_dict["init_qpos"])
+        assert np.allclose(diag_dict["qvel"], diag_dict["init_qvel"])
         return diag_dict
-    
+
     cur_env: gym.Env = spec.make()
 
     _test_initial_states(cur_env, seed=24)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -215,8 +215,8 @@ def test_robot_env_reset(spec):
             diag_dict["init_qpos"] = np.delete(diag_dict["init_qpos"], np.s_[-7:-5])
 
         # testing
-        assert np.allclose(diag_dict["qpos"], diag_dict["init_qpos"])
-        assert np.allclose(diag_dict["qvel"], diag_dict["init_qvel"])
+        assert np.all(diag_dict["qpos"] == diag_dict["init_qpos"])
+        assert np.all(diag_dict["qvel"] == diag_dict["init_qvel"])
         return diag_dict
 
     cur_env: gym.Env = spec.make()

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -194,7 +194,6 @@ def test_robot_env_reset(spec):
         })
 
         # exclude object location from environments
-        # if spec.id[:-3] in ['FetchPush', 'FetchPickAndPlace', 'FetchSlide',]:
         if np.any([tar in spec.id for tar in ['FetchPush', 'FetchPickAndPlace', 'FetchSlide',]]):
             diag_dict['qpos'] = np.delete(diag_dict['qpos'], np.s_[-7:-5])
             diag_dict['init_qpos'] = np.delete(diag_dict['init_qpos'], np.s_[-7:-5])

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -189,12 +189,8 @@ def test_robot_env_reset(spec):
     def _test_initial_states(env, seed=None):
         diag_dict = {}
 
-        init_obs = env.reset(seed=seed)
+        env.reset(seed=seed)
 
-        if isinstance(init_obs[0], dict):
-            diag_dict.update(**init_obs[0])
-        elif isinstance(init_obs[0], np.ndarray):
-            diag_dict.update({"observation": init_obs[0]})
         diag_dict.update(
             {
                 "qpos": env.unwrapped.data.qpos,
@@ -227,4 +223,3 @@ def test_robot_env_reset(spec):
 
     _test_initial_states(cur_env, seed=24)
     _test_initial_states(cur_env, seed=10)
-    return


### PR DESCRIPTION
Adding back the lines described in #251 to fix the initial state changes introduced in `gymnasium-robotics>=1.3.0, <=1.3.1`.

# Description

Adding back removed data setting lines removed in 1.3.0. Following Gymnasium's `mujoco_env.py` workflow, the procedure to reset an environment for Fetch and Robotic environments are:

1. `mujoco._mj_resetData(self.model, self.data)`
2. Update `self.data` to the saved initial data.
3. `mujoco.mf_forward(self.model, self.data)`

The second step changes for different environments. Changes in 1.3.0 removed the second step. The third step is called in `set_state()` in `mujoco_env.py`. 

Update impacted `Fetch` environments to V4 and `HandReach` environment to V3. Other Shadow Dexterous Hand environments are not impacted since they inherit `MujocoManipulateEnv` which has a overridden `_reset_sim()`.

Fixes #251 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
