### PR TITLE
Make logo image in `README.md` link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/Farama-Foundation/Gymnasium-Robotics/main/gymrobotics-revised-text.png" width="500px"/>
+  <a href = "https://robotics.farama.org/" target = "_blank"> <img src="https://raw.githubusercontent.com/Farama-Foundation/Gymnasium-Robotics/main/gymrobotics-revised-text.png" width="500px"/> </a>
 </p>
 
 This library contains a collection of Reinforcement Learning robotic environments that use the [Gymnasium](https://gymnasium.farama.org/) API. The environments run with the [MuJoCo](https://mujoco.org/) physics engine and the maintained [mujoco python bindings](https://mujoco.readthedocs.io/en/latest/python.html).


### PR DESCRIPTION
Clicking the logo image on the documentation launches the website in another tab

# Description

The logo has been updated to be clickable and opens the Gymnasium-Robotics website in a new tab when clicked. This change improves navigation by allowing users to visit the website without leaving the current page.


## Type of change

- [x] Documentation only change (no code changed)


### Screenshots

#### Before

![GR before](https://github.com/user-attachments/assets/36ac2d95-30d7-4df7-87c6-11eb095e7976)


#### After

![GR after](https://github.com/user-attachments/assets/9a3fd697-371f-47ba-ba51-acfb6681a593)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
