### PR TITLE
Fix rgba value in `oven_asset.xml` to be in `[0,1]`

### DIFF
--- a/gymnasium_robotics/envs/assets/kitchen_franka/kitchen_assets/item_assets/oven_asset.xml
+++ b/gymnasium_robotics/envs/assets/kitchen_franka/kitchen_assets/item_assets/oven_asset.xml
@@ -20,7 +20,7 @@
         <material name="oven_wood" texture="T_oven_wood" texrepeat="3 3" reflectance="0.7" shininess=".4" texuniform="false"/>
         <material name="oven_metal" rgba="1 1 1 1" texture="T_oven_metal" texrepeat="3 3" reflectance="1" shininess="1" texuniform="false"/>
         <material name="oven_black" rgba=".15 .15 .15 1" reflectance=".2" shininess=".2" />
-        <material name="oven_burner" rgba="2 0 0 1" reflectance=".2" shininess=".2" />
+        <material name="oven_burner" rgba="1 0 0 1" reflectance=".2" shininess=".2" />
         <material name="oven_block" rgba=".1 .1 .1 1"/>
         <material name="oven_collision_blue" rgba="0.3 0.3 1.0 0.5" shininess="0" specular="0"/>
     </asset>


### PR DESCRIPTION

# Description

The mujoco xml docs state that "All [rgba] components should be in the range [0 1]."
https://mujoco.readthedocs.io/en/stable/XMLreference.html#asset-material

MuJoCo's parser clearly let's this through. But it seems that mine is a little more strict.

I checked with the original author @abhishekunique, and he confirmed that it's just a bug (from his original work), and that it should be fixed.

Related to https://github.com/RobotLocomotion/drake/pull/22445.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

