### PR TITLE
Fix website doc build and remove env overwrite warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,14 @@ repos:
       - id: detect-private-key
       - id: debug-statements
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         exclude: .svg
         args:
           - --ignore-words-list=nd,reacher,thist,ths, arry
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         args:
@@ -36,17 +36,17 @@ repos:
           - --show-source
           - --statistics
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.20.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         args: ["--profile", "black"]
   - repo: https://github.com/python/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/pydocstyle

--- a/docs/_scripts/gen_mds.py
+++ b/docs/_scripts/gen_mds.py
@@ -1,5 +1,5 @@
 """
-   isort:skip_file
+isort:skip_file
 """
 
 import os
@@ -25,7 +25,8 @@ for env_spec in gym.envs.registry.values():
     if isinstance(env_spec.entry_point, str):
         if (
             env_spec.entry_point.startswith("gymnasium_robotics.envs")
-            and "MujocoPy" not in env_spec.entry_point
+            # and "MujocoPy" not in env_spec.entry_point
+            and "gymnasium_robotics.envs.mujoco" not in env_spec.entry_point
         ):
             all_envs.append(env_spec)  # Exclude Fetch and Shadow Hand environments
 

--- a/gymnasium_robotics/__init__.py
+++ b/gymnasium_robotics/__init__.py
@@ -1,11 +1,12 @@
 # noqa: D104
-from gymnasium.envs.registration import register
+import gymnasium
+from gymnasium import register
 
 from gymnasium_robotics.core import GoalEnv
 from gymnasium_robotics.envs.maze import maps
 from gymnasium_robotics.envs.multiagent_mujoco import mamujoco_v1
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"
 
 
 def register_robotics_envs():
@@ -1124,6 +1125,7 @@ def register_robotics_envs():
 
     # manipulation
 
+    gymnasium.registry.pop("Reacher-v2")
     register(
         id="Reacher-v2",
         entry_point="gymnasium_robotics.envs.mujoco.reacher_v2:ReacherEnv",
@@ -1131,6 +1133,7 @@ def register_robotics_envs():
         reward_threshold=-3.75,
     )
 
+    gymnasium.registry.pop("Pusher-v2")
     register(
         id="Pusher-v2",
         entry_point="gymnasium_robotics.envs.mujoco.pusher_v2:PusherEnv",
@@ -1140,6 +1143,7 @@ def register_robotics_envs():
 
     # balance
 
+    gymnasium.registry.pop("InvertedPendulum-v2")
     register(
         id="InvertedPendulum-v2",
         entry_point="gymnasium_robotics.envs.mujoco.inverted_pendulum_v2:InvertedPendulumEnv",
@@ -1147,6 +1151,7 @@ def register_robotics_envs():
         reward_threshold=950.0,
     )
 
+    gymnasium.registry.pop("InvertedDoublePendulum-v2")
     register(
         id="InvertedDoublePendulum-v2",
         entry_point="gymnasium_robotics.envs.mujoco.inverted_double_pendulum_v2:InvertedDoublePendulumEnv",
@@ -1156,6 +1161,7 @@ def register_robotics_envs():
 
     # runners
 
+    gymnasium.registry.pop("HalfCheetah-v2")
     register(
         id="HalfCheetah-v2",
         entry_point="gymnasium_robotics.envs.mujoco.half_cheetah_v2:HalfCheetahEnv",
@@ -1163,6 +1169,7 @@ def register_robotics_envs():
         reward_threshold=4800.0,
     )
 
+    gymnasium.registry.pop("HalfCheetah-v3")
     register(
         id="HalfCheetah-v3",
         entry_point="gymnasium_robotics.envs.mujoco.half_cheetah_v3:HalfCheetahEnv",
@@ -1170,6 +1177,7 @@ def register_robotics_envs():
         reward_threshold=4800.0,
     )
 
+    gymnasium.registry.pop("Hopper-v2")
     register(
         id="Hopper-v2",
         entry_point="gymnasium_robotics.envs.mujoco.hopper_v2:HopperEnv",
@@ -1177,6 +1185,7 @@ def register_robotics_envs():
         reward_threshold=3800.0,
     )
 
+    gymnasium.registry.pop("Hopper-v3")
     register(
         id="Hopper-v3",
         entry_point="gymnasium_robotics.envs.mujoco.hopper_v3:HopperEnv",
@@ -1184,6 +1193,7 @@ def register_robotics_envs():
         reward_threshold=3800.0,
     )
 
+    gymnasium.registry.pop("Swimmer-v2")
     register(
         id="Swimmer-v2",
         entry_point="gymnasium_robotics.envs.mujoco.swimmer_v2:SwimmerEnv",
@@ -1191,6 +1201,7 @@ def register_robotics_envs():
         reward_threshold=360.0,
     )
 
+    gymnasium.registry.pop("Swimmer-v3")
     register(
         id="Swimmer-v3",
         entry_point="gymnasium_robotics.envs.mujoco.swimmer_v3:SwimmerEnv",
@@ -1198,18 +1209,21 @@ def register_robotics_envs():
         reward_threshold=360.0,
     )
 
+    gymnasium.registry.pop("Walker2d-v2")
     register(
         id="Walker2d-v2",
         max_episode_steps=1000,
         entry_point="gymnasium_robotics.envs.mujoco.walker2d_v2:Walker2dEnv",
     )
 
+    gymnasium.registry.pop("Walker2d-v3")
     register(
         id="Walker2d-v3",
         max_episode_steps=1000,
         entry_point="gymnasium_robotics.envs.mujoco.walker2d_v3:Walker2dEnv",
     )
 
+    gymnasium.registry.pop("Ant-v2")
     register(
         id="Ant-v2",
         entry_point="gymnasium_robotics.envs.mujoco.ant_v2:AntEnv",
@@ -1217,6 +1231,7 @@ def register_robotics_envs():
         reward_threshold=6000.0,
     )
 
+    gymnasium.registry.pop("Ant-v3")
     register(
         id="Ant-v3",
         entry_point="gymnasium_robotics.envs.mujoco.ant_v3:AntEnv",
@@ -1224,18 +1239,21 @@ def register_robotics_envs():
         reward_threshold=6000.0,
     )
 
+    gymnasium.registry.pop("Humanoid-v2")
     register(
         id="Humanoid-v2",
         entry_point="gymnasium_robotics.envs.mujoco.humanoid_v2:HumanoidEnv",
         max_episode_steps=1000,
     )
 
+    gymnasium.registry.pop("Humanoid-v3")
     register(
         id="Humanoid-v3",
         entry_point="gymnasium_robotics.envs.mujoco.humanoid_v3:HumanoidEnv",
         max_episode_steps=1000,
     )
 
+    gymnasium.registry.pop("HumanoidStandup-v2")
     register(
         id="HumanoidStandup-v2",
         entry_point="gymnasium_robotics.envs.mujoco.humanoidstandup_v2:HumanoidStandupEnv",

--- a/gymnasium_robotics/envs/franka_kitchen/utils.py
+++ b/gymnasium_robotics/envs/franka_kitchen/utils.py
@@ -1,5 +1,4 @@
-"""Utility functions to read the file with the joints configuration of the Franka robot located at '../assets/kitchen_franka/franka_assets/franka_config.xml'.
-"""
+"""Utility functions to read the file with the joints configuration of the Franka robot located at '../assets/kitchen_franka/franka_assets/franka_config.xml'."""
 
 import xml.etree.ElementTree as ET
 

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/hand_env.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/hand_env.py
@@ -13,7 +13,7 @@ DEFAULT_CAMERA_CONFIG = {
 
 
 def get_base_hand_env(
-    RobotEnvClass: Union[MujocoPyRobotEnv, MujocoRobotEnv]
+    RobotEnvClass: Union[MujocoPyRobotEnv, MujocoRobotEnv],
 ) -> Union[MujocoPyRobotEnv, MujocoRobotEnv]:
     """Factory function that returns a BaseHandEnv class that inherits from MujocoPyRobotEnv or MujocoRobotEnv depending on the mujoco python bindings."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gymnasium-robotics"
-description = "Robotics environments for the Gymnasium repo."
+description = "RL Robotics environments with Gymnasium API."
 readme = "README.md"
 requires-python = ">= 3.10"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
@@ -31,6 +31,7 @@ dependencies = [
     "Jinja2>=3.0.3",
     "imageio",
     "setuptools",
+    "packaging",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
# Description

The website doc is failing due to the mujoco-py environment not having the docs here, as they are still part of gymnasium 

The gymnasium has errors for the mujoco-py environment; therefore, we overwrite them currently, which raises a warning. 
It's fixed by removing the gymnasium version and re-registering the environment.
