### PR TITLE
Fix stale PointMaze goal after target reset

### DIFF
--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -392,16 +392,24 @@ class PointMazeEnv(MazeEnv, EzPickle):
     def step(self, action):
         obs, _, _, _, info = self.point_env.step(action)
         obs_dict = self._get_obs(obs)
+        # Transition signals use the goal that was active while the action executed.
+        transition_goal = obs_dict["desired_goal"]
 
-        reward = self.compute_reward(obs_dict["achieved_goal"], self.goal, info)
-        terminated = self.compute_terminated(obs_dict["achieved_goal"], self.goal, info)
-        truncated = self.compute_truncated(obs_dict["achieved_goal"], self.goal, info)
+        reward = self.compute_reward(obs_dict["achieved_goal"], transition_goal, info)
+        terminated = self.compute_terminated(
+            obs_dict["achieved_goal"], transition_goal, info
+        )
+        truncated = self.compute_truncated(
+            obs_dict["achieved_goal"], transition_goal, info
+        )
         info["success"] = bool(
-            np.linalg.norm(obs_dict["achieved_goal"] - self.goal) <= 0.45
+            np.linalg.norm(obs_dict["achieved_goal"] - transition_goal) <= 0.45
         )
 
         # Update the goal position if necessary
         self.update_goal(obs_dict["achieved_goal"])
+        # Returned desired_goal is the goal for the next policy step.
+        obs_dict["desired_goal"] = self.goal.copy()
 
         return obs_dict, reward, terminated, truncated, info
 

--- a/tests/envs/maze/test_point_maze.py
+++ b/tests/envs/maze/test_point_maze.py
@@ -43,3 +43,77 @@ def test_goal_cell():
     obs = env.reset(options={"goal_cell": [2, 1]}, seed=42)[0]
     desired_goal = np.array([-0.36302198, -0.53056078])
     np.testing.assert_almost_equal(desired_goal, obs["desired_goal"], decimal=4)
+
+
+def test_step_returns_updated_goal_after_goal_reset():
+    """After reaching the goal in a continuing task, step should return the new desired_goal.
+
+    Regression for Issue #258: with continuing_task=True and reset_target=True, update_goal
+    changes the internal goal after success, but the returned observation currently still
+    contains the old desired_goal. The next policy call must see the updated goal.
+    """
+    maze_map = [
+        [1, 1, 1, 1, 1],
+        [1, "r", "g", "g", 1],
+        [1, 1, 1, 1, 1],
+    ]
+    # position_noise_range cannot be passed through gym.make: PointMazeEnv forwards
+    # unused kwargs into PointEnv/MujocoEnv, which rejects this MazeEnv-only argument.
+    env = gym.make(
+        "PointMaze_UMaze-v3",
+        maze_map=maze_map,
+        continuing_task=True,
+        reset_target=True,
+        reward_type="sparse",
+        max_episode_steps=100,
+    )
+    try:
+        env.unwrapped.position_noise_range = 0.0
+        obs, _ = env.reset(
+            seed=0,
+            options={
+                "reset_cell": np.array([1, 1]),
+                "goal_cell": np.array([1, 2]),
+            },
+        )
+        old_goal = obs["desired_goal"].copy()
+
+        # Public API cannot teleport onto the goal without an expert policy or long
+        # random rollouts; set MuJoCo state so the next step reliably triggers success.
+        point_env = env.unwrapped.point_env
+        point_env.set_state(
+            np.concatenate([old_goal, point_env.data.qpos[2:]]),
+            np.zeros_like(point_env.data.qvel),
+        )
+
+        obs, reward, terminated, truncated, info = env.step(
+            np.zeros(env.action_space.shape, dtype=np.float32)
+        )
+        new_goal = env.unwrapped.goal.copy()
+        returned_desired_goal = obs["desired_goal"]
+
+        assert info["success"] is True
+        assert reward == 1.0
+        assert terminated is False
+        assert truncated is False
+        assert not np.allclose(old_goal, new_goal), (
+            "Expected update_goal to switch the internal goal after success, "
+            f"but old_goal={old_goal} new_goal={new_goal}"
+        )
+        np.testing.assert_allclose(
+            returned_desired_goal,
+            new_goal,
+            err_msg=(
+                "Returned desired_goal should match the post-step internal goal so the "
+                "next policy call tracks the new target. "
+                f"old_goal={old_goal}, returned_desired_goal={returned_desired_goal}, "
+                f"internal_goal={new_goal}"
+            ),
+        )
+        assert not np.allclose(returned_desired_goal, old_goal), (
+            "Returned desired_goal should not remain the pre-switch goal. "
+            f"old_goal={old_goal}, returned_desired_goal={returned_desired_goal}, "
+            f"internal_goal={new_goal}"
+        )
+    finally:
+        env.close()


### PR DESCRIPTION
Supersedes #318 after the upstream repository history was rewritten. This branch was rebuilt on top of the latest main as requested.


# Description

This draft proposes a PointMaze-only fix for the stale `desired_goal` returned after a target reset in a continuing task.

When the agent reaches the current target with `continuing_task=True` and `reset_target=True`, the environment currently updates its internal goal after constructing the observation. The returned observation therefore contains the previous goal, while the environment is already tracking the next goal.

The proposed change keeps the transition reward, termination signal, and `info["success"]` tied to the goal active when the action was executed. After the transition signals are calculated and the internal target is updated, the returned observation is synchronized with the new target so that the next policy call receives the current goal.

A deterministic regression test reproduces the target switch without requiring an expert policy, dataset download, or random rollout.

Refs #258

## Semantic consideration

On a target-switch transition, the returned observation contains the next target while the reward still belongs to the target that was just reached. As a result, directly recomputing the transition reward with the returned `observation["desired_goal"]` produces a different value.

This draft intentionally leaves that interface decision open. It does not add a new `info` field or modify `compute_reward`. Maintainer guidance is still needed on whether the previous target should be retained in `info`, whether an alternative transition convention is preferred, and whether this change should be introduced through a new Maze environment version.

The same step ordering exists in AntMaze, but this draft limits the implementation and regression test to PointMaze until the intended scope is confirmed.

## Testing

Passed locally:

- `pre-commit run --all-files`
- `pytest -q tests/envs/maze/test_point_maze.py` — 4 passed
- `pytest -q tests/envs/maze` — 8 passed
- `pytest -q tests/test_envs.py -k PointMaze` — 100 passed

The complete test suite could not be collected on Windows because the legacy `mujoco_py` tests require a local MuJoCo 2.1 installation at `~/.mujoco/mujoco210`. The same collection failure was reproduced on the unmodified upstream `main` commit. No PointMaze or Maze tests failed.

## Type of change

- [ ] Documentation only change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] This change requires a documentation update

# Checklist

- [x] I have run `pre-commit run --all-files`
- [x] I have commented the non-obvious transition ordering
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings in the relevant test suites
- [x] I have added a test that reproduces the issue
- [x] New and existing relevant tests pass locally