### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,6 +6,9 @@
 # derived from https://github.com/Farama-Foundation/PettingZoo/blob/e230f4d80a5df3baf9bd905149f6d4e8ce22be31/.github/workflows/build-publish.yml
 name: Build artifact for PyPI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Gymnasium-Robotics/security/code-scanning/3](https://github.com/Farama-Foundation/Gymnasium-Robotics/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults. For this workflow, a minimal safe baseline is:

- `contents: read` (needed for checkout)
  
No additional write scopes are required by the shown steps. This preserves existing functionality while documenting and enforcing restricted token access regardless of repo/org defaults.

Change location: `.github/workflows/pypi-publish.yml`, immediately after `name:` (before `on:`), adding:

```yml
permissions:
  contents: read
```

No imports/methods/dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
