### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   build-wheels:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +36,8 @@ jobs:
         path: dist
 
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs:
     - build-wheels


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Gymnasium-Robotics/security/code-scanning/2](https://github.com/Farama-Foundation/Gymnasium-Robotics/security/code-scanning/2)

Add explicit `permissions` blocks so each job gets only what it needs.

Best minimal fix without changing functionality:
- In `.github/workflows/pypi-publish.yml`, add:
  - For `build-wheels`: `contents: read` (needed for checkout).
  - For `publish`: `contents: read` (sufficient for downloading artifacts/publishing to PyPI with external token).
- Keep permissions at job scope (instead of workflow root) since jobs have different intent and this is clearest least-privilege documentation.

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
