### PR TITLE
Answer compute_terminated per goal, not per batch

### DIFF
--- a/gymnasium_robotics/envs/maze/maze.py
+++ b/gymnasium_robotics/envs/maze/maze.py
@@ -283,13 +283,22 @@ class MazeEnv(GoalEnv):
     def compute_terminated(
         self, achieved_goal: np.ndarray, desired_goal: np.ndarray, info
     ) -> bool:
+        # `compute_reward` above takes the norm along the last axis. Without it a
+        # batch of goals collapses into the Frobenius norm of the whole batch, so
+        # the answer described no row in particular.
+        reached = np.linalg.norm(achieved_goal - desired_goal, axis=-1) <= 0.45
+        batched = reached.ndim > 0
+
         if not self.continuing_task:
             # If task is episodic terminate the episode when the goal is reached
-            return bool(np.linalg.norm(achieved_goal - desired_goal) <= 0.45)
+            return reached if batched else bool(reached)
         else:
             # Continuing tasks don't terminate, episode will be truncated when time limit is reached (`max_episode_steps`)
             if (
-                bool(np.linalg.norm(achieved_goal - desired_goal) <= 0.45)
+                # A batch of goals is a relabelling query rather than a step, so
+                # it must not move the goal the environment is working towards.
+                not batched
+                and bool(reached)
                 and len(self.maze.unique_goal_locations) > 1
             ):
                 # Generate another goal
@@ -299,7 +308,7 @@ class MazeEnv(GoalEnv):
                 # Update the position of the target site for visualization
                 self.update_target_site_pos()
 
-            return False
+            return np.zeros_like(reached) if batched else False
 
     def compute_truncated(
         self, achieved_goal: np.ndarray, desired_goal: np.ndarray, info

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -390,12 +390,17 @@ class MazeEnv(GoalEnv):
     def compute_terminated(
         self, achieved_goal: np.ndarray, desired_goal: np.ndarray, info
     ) -> bool:
+        # `compute_reward` above takes the norm along the last axis. Without it a
+        # batch of goals collapses into the Frobenius norm of the whole batch, so
+        # the answer described no row in particular.
+        reached = np.linalg.norm(achieved_goal - desired_goal, axis=-1) <= 0.45
+
         if not self.continuing_task:
             # If task is episodic terminate the episode when the goal is reached
-            return bool(np.linalg.norm(achieved_goal - desired_goal) <= 0.45)
+            return reached if reached.ndim else bool(reached)
         else:
             # Continuing tasks don't terminate, episode will be truncated when time limit is reached (`max_episode_steps`)
-            return False
+            return np.zeros_like(reached) if reached.ndim else False
 
     def update_goal(self, achieved_goal: np.ndarray) -> None:
         """Update goal position if continuing task and within goal radius."""

--- a/tests/envs/maze/test_maze_goal_api.py
+++ b/tests/envs/maze/test_maze_goal_api.py
@@ -1,0 +1,54 @@
+import gymnasium as gym
+import numpy as np
+import pytest
+
+import gymnasium_robotics
+
+gym.register_envs(gymnasium_robotics)
+
+
+# PointMaze is built on `maze_v4.MazeEnv`, AntMaze-v3 on the older `maze.MazeEnv`.
+@pytest.mark.parametrize("env_id", ["PointMaze_UMaze-v3", "AntMaze_UMaze-v3"])
+def test_compute_terminated_answers_per_goal(env_id):
+    """A batch of goals must be answered row by row, the way `compute_reward` is.
+
+    `compute_terminated` took the norm without `axis=-1`, which collapses a
+    batch into the Frobenius norm of the whole array. The single answer that
+    came back described no row in particular, so relabelling a batch of
+    transitions — what the goal-env API exists for — got one verdict for all of
+    them.
+    """
+    env = gym.make(env_id, continuing_task=False)
+    unwrapped = env.unwrapped
+    obs, _ = env.reset(seed=0)
+
+    desired = obs["desired_goal"]
+    near = desired + 0.01
+    far = desired + np.array([5.0, 5.0])
+    achieved = np.stack([near, far, near, far])
+    desired_batch = np.repeat(desired[None], len(achieved), axis=0)
+
+    terminated = np.asarray(
+        unwrapped.compute_terminated(achieved, desired_batch, [{}] * len(achieved))
+    )
+    assert terminated.shape == (4,)
+    assert terminated.tolist() == [True, False, True, False]
+
+    env.close()
+
+
+@pytest.mark.parametrize("env_id", ["PointMaze_UMaze-v3", "AntMaze_UMaze-v3"])
+def test_compute_terminated_single_goal_is_a_bool(env_id):
+    """A single pair keeps answering with a plain bool."""
+    env = gym.make(env_id, continuing_task=False)
+    unwrapped = env.unwrapped
+    obs, _ = env.reset(seed=0)
+
+    desired = obs["desired_goal"]
+    assert unwrapped.compute_terminated(desired + 0.01, desired, {}) is True
+    assert (
+        unwrapped.compute_terminated(desired + np.array([5.0, 5.0]), desired, {})
+        is False
+    )
+
+    env.close()


### PR DESCRIPTION
# Description

`MazeEnv.compute_reward` takes the norm along the last axis. `compute_terminated`,
five lines below it in the same class, takes it without an axis:

```python
def compute_reward(self, achieved_goal, desired_goal, info):
    distance = np.linalg.norm(achieved_goal - desired_goal, axis=-1)
    ...

def compute_terminated(self, achieved_goal, desired_goal, info):
    if not self.continuing_task:
        return bool(np.linalg.norm(achieved_goal - desired_goal) <= 0.45)
```

For a batch of goals that collapses into the Frobenius norm of the whole array,
so every row gets one shared verdict derived from a distance that belongs to
none of them:

```python
env = gym.make("PointMaze_UMaze-v3", continuing_task=False)
obs, _ = env.reset(seed=0)
desired = obs["desired_goal"]

achieved = np.stack([desired + 0.01, desired + 5.0, desired + 0.01, desired + 5.0])
desired_batch = np.repeat(desired[None], 4, axis=0)

env.unwrapped.compute_reward(achieved, desired_batch, [{}] * 4)
# array([1., 0., 1., 0.])          <- per row, correct

env.unwrapped.compute_terminated(achieved, desired_batch, [{}] * 4)
# False                            <- one answer, from a norm of 10.0
```

Relabelling a batch of transitions is what the goal-env API exists for, and it
is the only way these methods are reached from outside: the environment itself
calls them with a single goal, one per step. So the batched path has never
returned anything meaningful, and nothing in the single-goal path changes here —
`compute_terminated(goal, goal, {})` still answers with a plain `bool`.

Both maze modules carry it: `maze.py` (behind AntMaze-v3) and `maze_v4.py`
(behind PointMaze and AntMaze-v4/v5).

## One behaviour change worth flagging

`maze.MazeEnv.compute_terminated` regenerates the goal as a side effect when the
agent is within 0.45 of it. That now runs for single goals only. A batch is a
query about hypothetical goals, so it should not move the goal the environment
is working towards — and its previous trigger was the collapsed norm anyway, so
it fired on a condition no row described. Say the word if you would rather it
kept firing on some reduction of the batch.

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable — no rendering or visual change.

## Tests

New `tests/envs/maze/test_maze_goal_api.py`, parametrised over
`PointMaze_UMaze-v3` and `AntMaze_UMaze-v3` so both maze modules are covered: a
batch of four goals gets `[True, False, True, False]`, and a single pair still
answers with a plain `bool`. The batched cases fail on `main` for both
environments and pass here.

`tests/envs/maze/` is 11 passed, and `tests/test_envs.py -k Maze` is 400 passed.
`pre-commit run` is clean on the three files.
