### PR TITLE
Name the goal-env arguments the way GoalEnv does

### DIFF
--- a/gymnasium_robotics/envs/fetch/fetch_env.py
+++ b/gymnasium_robotics/envs/fetch/fetch_env.py
@@ -71,9 +71,9 @@ def get_base_fetch_env(RobotEnvClass: Union[MujocoPyRobotEnv, MujocoRobotEnv]):
         # GoalEnv methods
         # ----------------------------
 
-        def compute_reward(self, achieved_goal, goal, info):
+        def compute_reward(self, achieved_goal, desired_goal, info):
             # Compute distance between goal and the achieved goal.
-            d = goal_distance(achieved_goal, goal)
+            d = goal_distance(achieved_goal, desired_goal)
             if self.reward_type == "sparse":
                 return -(d > self.distance_threshold).astype(np.float32)
             else:

--- a/gymnasium_robotics/envs/robot_env.py
+++ b/gymnasium_robotics/envs/robot_env.py
@@ -107,7 +107,7 @@ class BaseRobotEnv(GoalEnv):
         """All the available environments are currently continuing tasks and non-time dependent. The objective is to reach the goal for an indefinite period of time."""
         return False
 
-    def compute_truncated(self, achievec_goal, desired_goal, info):
+    def compute_truncated(self, achieved_goal, desired_goal, info):
         """The environments will be truncated only if setting a time limit with max_steps which will automatically wrap the environment in a gymnasium TimeLimit wrapper."""
         return False
 

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/manipulate.py
@@ -117,12 +117,14 @@ def get_base_manipulate_env(HandEnvClass: Union[MujocoHandEnv, MujocoPyHandEnv])
         # GoalEnv methods
         # ----------------------------
 
-        def compute_reward(self, achieved_goal, goal, info):
+        def compute_reward(self, achieved_goal, desired_goal, info):
             if self.reward_type == "sparse":
-                success = self._is_success(achieved_goal, goal).astype(np.float32)
+                success = self._is_success(achieved_goal, desired_goal).astype(
+                    np.float32
+                )
                 return success - 1.0
             else:
-                d_pos, d_rot = self._goal_distance(achieved_goal, goal)
+                d_pos, d_rot = self._goal_distance(achieved_goal, desired_goal)
                 # We weigh the difference in position to avoid that `d_pos` (in meters) is completely
                 # dominated by `d_rot` (in radians).
                 return -(10.0 * d_pos + d_rot)

--- a/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
+++ b/gymnasium_robotics/envs/shadow_dexterous_hand/reach.py
@@ -89,8 +89,8 @@ def get_base_hand_reach_env(HandEnvClass: Union[MujocoHandEnv, MujocoPyHandEnv])
         # GoalEnv methods
         # ----------------------------
 
-        def compute_reward(self, achieved_goal, goal, info):
-            d = goal_distance(achieved_goal, goal)
+        def compute_reward(self, achieved_goal, desired_goal, info):
+            d = goal_distance(achieved_goal, desired_goal)
             if self.reward_type == "sparse":
                 return -(d > self.distance_threshold).astype(np.float32)
             else:

--- a/tests/test_goal_env_api.py
+++ b/tests/test_goal_env_api.py
@@ -1,0 +1,40 @@
+import gymnasium as gym
+import pytest
+
+import gymnasium_robotics
+
+gym.register_envs(gymnasium_robotics)
+
+
+# One environment per family that overrides the goal-env methods.
+@pytest.mark.parametrize(
+    "env_id",
+    [
+        "FetchReach-v4",
+        "HandReach-v3",
+        "HandManipulateBlock-v1",
+        "PointMaze_UMaze-v3",
+        "AntMaze_UMaze-v3",
+    ],
+)
+@pytest.mark.parametrize(
+    "method", ["compute_reward", "compute_terminated", "compute_truncated"]
+)
+def test_goal_methods_take_the_documented_keywords(env_id: str, method: str):
+    """`GoalEnv` names the arguments `achieved_goal` and `desired_goal`.
+
+    Overrides that renamed them broke every keyword call: the Fetch and hand
+    environments called the second one `goal`, and `BaseRobotEnv.compute_truncated`
+    carried a typo, `achievec_goal`. `core.GoalEnv` documents the interface these
+    override, so the names have to match it.
+    """
+    env = gym.make(env_id)
+    obs, _ = env.reset(seed=0)
+
+    getattr(env.unwrapped, method)(
+        achieved_goal=obs["achieved_goal"],
+        desired_goal=obs["desired_goal"],
+        info={},
+    )
+
+    env.close()


### PR DESCRIPTION
# Description

`core.GoalEnv` declares the three goal methods with `achieved_goal` and
`desired_goal`, and its own docstrings show them being called that way:

```python
assert reward == env.compute_reward(ob['achieved_goal'], ob['desired_goal'], info)
```

Three overrides renamed the second argument to `goal`, and
`BaseRobotEnv.compute_truncated` carries a typo — `achievec_goal`. So a keyword
call fails on every Fetch and hand environment, while `compute_terminated`
sitting right next to it accepts the same call:

```python
env = gym.make("FetchReach-v4")
obs, _ = env.reset(seed=0)
u = env.unwrapped

u.compute_terminated(achieved_goal=obs["achieved_goal"], desired_goal=obs["desired_goal"], info={})
# fine

u.compute_truncated(achieved_goal=obs["achieved_goal"], desired_goal=obs["desired_goal"], info={})
# TypeError: BaseRobotEnv.compute_truncated() got an unexpected keyword argument 'achieved_goal'

u.compute_reward(achieved_goal=obs["achieved_goal"], desired_goal=obs["desired_goal"], info={})
# TypeError: BaseFetchEnv.compute_reward() got an unexpected keyword argument 'desired_goal'
```

Four names change:

| file | was | now |
| ---- | --- | --- |
| `envs/robot_env.py` | `compute_truncated(self, achievec_goal, ...)` | `achieved_goal` |
| `envs/fetch/fetch_env.py` | `compute_reward(self, achieved_goal, goal, info)` | `desired_goal` |
| `envs/shadow_dexterous_hand/manipulate.py` | same | `desired_goal` |
| `envs/shadow_dexterous_hand/reach.py` | same | `desired_goal` |

## What this could break

Renaming a public parameter is an API change on paper. Anyone passing
`goal=...` today would have to switch to `desired_goal=...` — but they would be
depending on a name that contradicts the interface `core.GoalEnv` documents,
and the sibling methods on the same classes never accepted it. Every call site
inside the package passes these positionally, so nothing internal moves. Happy
to keep `goal` as a deprecated alias instead if you would rather not touch the
signature.

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable — no rendering or visual change.

## Tests

New `tests/test_goal_env_api.py`: all three methods, called with the documented
keywords, across one environment per family that overrides them — Fetch, hand
reach, hand manipulate, PointMaze and AntMaze-v3. Six of the fifteen cases fail
on `main`; all fifteen pass here.

`tests/test_envs.py -k "Fetch or Hand or Maze"` is 770 passed. `pre-commit run`
is clean on the five files.
