### PR TITLE
Fix continuing-task maze goal rollover semantics

### DIFF
--- a/gymnasium_robotics/envs/maze/ant_maze_v4.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v4.py
@@ -107,18 +107,19 @@ class AntMazeEnv(MazeEnv, EzPickle):
 
     def step(self, action):
         ant_obs, _, _, _, info = self.ant_env.step(action)
-        obs = self._get_obs(ant_obs)
-
-        reward = self.compute_reward(obs["achieved_goal"], self.goal, info)
-        terminated = self.compute_terminated(obs["achieved_goal"], self.goal, info)
-        truncated = self.compute_truncated(obs["achieved_goal"], self.goal, info)
-        info["success"] = bool(np.linalg.norm(obs["achieved_goal"] - self.goal) <= 0.45)
+        achieved_goal = ant_obs[:2]
+        info["success"] = bool(np.linalg.norm(achieved_goal - self.goal) <= 0.45)
 
         if self.render_mode == "human":
             self.render()
 
         # Update the goal position if necessary
-        self.update_goal(obs["achieved_goal"])
+        self.update_goal(achieved_goal)
+
+        obs = self._get_obs(ant_obs)
+        reward = self.compute_reward(obs["achieved_goal"], self.goal, info)
+        terminated = self.compute_terminated(obs["achieved_goal"], self.goal, info)
+        truncated = self.compute_truncated(obs["achieved_goal"], self.goal, info)
 
         return obs, reward, terminated, truncated, info
 

--- a/gymnasium_robotics/envs/maze/ant_maze_v5.py
+++ b/gymnasium_robotics/envs/maze/ant_maze_v5.py
@@ -294,18 +294,19 @@ class AntMazeEnv(MazeEnv, EzPickle):
 
     def step(self, action):
         ant_obs, _, _, _, info = self.ant_env.step(action)
-        obs = self._get_obs(ant_obs)
-
-        reward = self.compute_reward(obs["achieved_goal"], self.goal, info)
-        terminated = self.compute_terminated(obs["achieved_goal"], self.goal, info)
-        truncated = self.compute_truncated(obs["achieved_goal"], self.goal, info)
-        info["success"] = bool(np.linalg.norm(obs["achieved_goal"] - self.goal) <= 0.45)
+        achieved_goal = ant_obs[:2]
+        info["success"] = bool(np.linalg.norm(achieved_goal - self.goal) <= 0.45)
 
         if self.render_mode == "human":
             self.render()
 
         # Update the goal position if necessary
-        self.update_goal(obs["achieved_goal"])
+        self.update_goal(achieved_goal)
+
+        obs = self._get_obs(ant_obs)
+        reward = self.compute_reward(obs["achieved_goal"], self.goal, info)
+        terminated = self.compute_terminated(obs["achieved_goal"], self.goal, info)
+        truncated = self.compute_truncated(obs["achieved_goal"], self.goal, info)
 
         return obs, reward, terminated, truncated, info
 

--- a/gymnasium_robotics/envs/maze/maze_v4.py
+++ b/gymnasium_robotics/envs/maze/maze_v4.py
@@ -402,7 +402,7 @@ class MazeEnv(GoalEnv):
 
         if (
             self.continuing_task
-            and self.reset_target
+            and not self.reset_target
             and bool(np.linalg.norm(achieved_goal - self.goal) <= 0.45)
             and len(self.maze.unique_goal_locations) > 1
         ):

--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -391,17 +391,16 @@ class PointMazeEnv(MazeEnv, EzPickle):
 
     def step(self, action):
         obs, _, _, _, info = self.point_env.step(action)
-        obs_dict = self._get_obs(obs)
+        achieved_goal = obs[:2]
+        info["success"] = bool(np.linalg.norm(achieved_goal - self.goal) <= 0.45)
 
+        # Update the goal position if necessary
+        self.update_goal(achieved_goal)
+
+        obs_dict = self._get_obs(obs)
         reward = self.compute_reward(obs_dict["achieved_goal"], self.goal, info)
         terminated = self.compute_terminated(obs_dict["achieved_goal"], self.goal, info)
         truncated = self.compute_truncated(obs_dict["achieved_goal"], self.goal, info)
-        info["success"] = bool(
-            np.linalg.norm(obs_dict["achieved_goal"] - self.goal) <= 0.45
-        )
-
-        # Update the goal position if necessary
-        self.update_goal(obs_dict["achieved_goal"])
 
         return obs_dict, reward, terminated, truncated, info
 

--- a/tests/envs/maze/test_point_maze.py
+++ b/tests/envs/maze/test_point_maze.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
+
 import gymnasium as gym
 import numpy as np
-
 import gymnasium_robotics
+from gymnasium_robotics.envs.maze.maze_v4 import MazeEnv
+from gymnasium_robotics.envs.maze.point_maze import PointMazeEnv
 
 gym.register_envs(gymnasium_robotics)
 
@@ -43,3 +46,45 @@ def test_goal_cell():
     obs = env.reset(options={"goal_cell": [2, 1]}, seed=42)[0]
     desired_goal = np.array([-0.36302198, -0.53056078])
     np.testing.assert_almost_equal(desired_goal, obs["desired_goal"], decimal=4)
+
+
+def test_update_goal_rolls_target_for_continuing_tasks():
+    env = MazeEnv.__new__(MazeEnv)
+    env.continuing_task = True
+    env.reset_target = False
+    env.goal = np.array([0.0, 0.0])
+    env.maze = SimpleNamespace(unique_goal_locations=[0, 1])
+    env.generate_target_goal = lambda: np.array([1.0, 1.0])
+    env.add_xy_position_noise = lambda goal: goal
+    update_calls = {"count": 0}
+    env.update_target_site_pos = lambda: update_calls.__setitem__("count", update_calls["count"] + 1)
+
+    MazeEnv.update_goal(env, np.array([0.1, 0.1]))
+
+    np.testing.assert_array_equal(env.goal, np.array([1.0, 1.0]))
+    assert update_calls["count"] == 1
+
+
+def test_point_maze_step_returns_post_rollover_goal():
+    env = PointMazeEnv.__new__(PointMazeEnv)
+    env.goal = np.array([0.0, 0.0])
+    env.point_env = SimpleNamespace(
+        step=lambda action: (np.array([0.0, 0.0, 0.5, -0.25]), None, None, None, {})
+    )
+    env.compute_reward = lambda achieved_goal, desired_goal, info: float(
+        np.allclose(desired_goal, [1.0, 1.0])
+    )
+    env.compute_terminated = lambda achieved_goal, desired_goal, info: bool(
+        np.allclose(desired_goal, [1.0, 1.0])
+    )
+    env.compute_truncated = lambda achieved_goal, desired_goal, info: False
+    env.update_goal = lambda achieved_goal: setattr(env, "goal", np.array([1.0, 1.0]))
+
+    obs, reward, terminated, truncated, info = PointMazeEnv.step(env, None)
+
+    np.testing.assert_array_equal(obs["achieved_goal"], np.array([0.0, 0.0]))
+    np.testing.assert_array_equal(obs["desired_goal"], np.array([1.0, 1.0]))
+    assert reward == 1.0
+    assert terminated is True
+    assert truncated is False
+    assert info["success"] is True


### PR DESCRIPTION
## Summary

- rotate goals when `continuing_task=True` and `reset_target=False`
- record success against the goal just reached, then build returned observations and rewards against the rolled goal
- apply the same ordering to PointMaze and both AntMaze versions
- add focused regressions without weakening existing MuJoCo coverage

## Why

Continuing maze tasks could return a `desired_goal` from the previous episode segment and used an inverted `reset_target` guard. This fixes the observation/info semantics reported in #258.

## Verification

- `python -m pytest tests/envs/maze/test_point_maze.py -q` (5 passed)
- source-level smoke checks for PointMaze, AntMaze v4, and AntMaze v5
- `python -m py_compile` on all touched Python files

Fixes #258