### PR TITLE
Fix joint-type comparisons with MuJoCo 3.12

### DIFF
--- a/gymnasium_robotics/utils/mujoco_utils.py
+++ b/gymnasium_robotics/utils/mujoco_utils.py
@@ -131,7 +131,7 @@ def set_joint_qpos(model, data, name, value):
     """Set the joint positions (qpos) of the model."""
     joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
     assert joint_id != -1, f"Joint with name '{name}' is not part of the model!"
-    joint_type = model.jnt_type[joint_id]
+    joint_type = int(model.jnt_type[joint_id])
     joint_addr = model.jnt_qposadr[joint_id]
 
     if joint_type == mujoco.mjtJoint.mjJNT_FREE:
@@ -156,7 +156,7 @@ def set_joint_qvel(model, data, name, value):
     """Set the joints linear and angular (qvel) of the model."""
     joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
     assert joint_id != -1, f"Joint with name '{name}' is not part of the model!"
-    joint_type = model.jnt_type[joint_id]
+    joint_type = int(model.jnt_type[joint_id])
     joint_addr = model.jnt_dofadr[joint_id]
 
     if joint_type == mujoco.mjtJoint.mjJNT_FREE:
@@ -181,7 +181,7 @@ def get_joint_qpos(model, data, name):
     """Return the joints position and orientation (qpos) of the model."""
     joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
     assert joint_id != -1, f"Joint with name '{name}' is not part of the model!"
-    joint_type = model.jnt_type[joint_id]
+    joint_type = int(model.jnt_type[joint_id])
     joint_addr = model.jnt_qposadr[joint_id]
 
     if joint_type == mujoco.mjtJoint.mjJNT_FREE:
@@ -202,7 +202,7 @@ def get_joint_qvel(model, data, name):
     """Return the joints linear and angular velocities (qvel) of the model."""
     joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
     assert joint_id != -1, f"Joint with name '{name}' is not part of the model!"
-    joint_type = model.jnt_type[joint_id]
+    joint_type = int(model.jnt_type[joint_id])
     joint_addr = model.jnt_dofadr[joint_id]
 
     if joint_type == mujoco.mjtJoint.mjJNT_FREE:

--- a/tests/test_mujoco_utils.py
+++ b/tests/test_mujoco_utils.py
@@ -1,0 +1,37 @@
+import mujoco
+import numpy as np
+import pytest
+
+from gymnasium_robotics.utils import mujoco_utils
+
+
+@pytest.mark.parametrize("joint_type", ["hinge", "slide"])
+@pytest.mark.parametrize("field", ["qpos", "qvel"])
+def test_scalar_joint_state(joint_type, field):
+    """Read and write scalar joints without changing neighboring joint state."""
+    model = mujoco.MjModel.from_xml_string(
+        f"""
+        <mujoco>
+          <worldbody>
+            <body>
+              <joint name="neighbor" type="hinge"/>
+              <geom size="0.1"/>
+            </body>
+            <body pos="1 0 0">
+              <joint name="target" type="{joint_type}"/>
+              <geom size="0.1"/>
+            </body>
+          </worldbody>
+        </mujoco>
+        """
+    )
+    data = mujoco.MjData(model)
+    state = getattr(data, field)
+    state[:] = [0.25, 0.5]
+
+    getter = getattr(mujoco_utils, f"get_joint_{field}")
+    setter = getattr(mujoco_utils, f"set_joint_{field}")
+    np.testing.assert_array_equal(getter(model, data, "target"), [0.5])
+    setter(model, data, "target", 0.75)
+    np.testing.assert_array_equal(state, [0.25, 0.75])
+    np.testing.assert_array_equal(getter(model, data, "target"), [0.75])


### PR DESCRIPTION
# Description

Fix joint-state access with MuJoCo 3.12.0. With NumPy 1.26.4, comparing a MuJoCo enum to a NumPy integer returns false even when the numeric values match. Tuple membership uses that comparison order, causing valid hinge and slide joints to fail assertions. The unchanged baseline produced 344 test failures.

Convert joint types from NumPy scalars to Python integers in all four position/velocity getters and setters. Add regression coverage for reading and writing hinge and slide joints while preserving neighboring joint state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Validation

- All four regression cases fail before the fix and pass afterward with MuJoCo 3.12.0 and NumPy 1.26.4.
- Regression cases also pass with MuJoCo 3.10.0.
- The original FetchSlide environment failure passes after the fix.
- Repository pre-commit checks pass for both changed files.
- Full GitHub Actions build matrix passes on Python 3.10, 3.11, 3.12, and 3.13 for both push and pull-request runs.
- GitHub pre-commit, CodeQL, and wheel-building checks pass.
