### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-            python-version: '3.10'
+            python-version: '3.11'
 
       - name: Install docs requirements
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/build-docs-version.yml
+++ b/.github/workflows/build-docs-version.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-            python-version: '3.10'
+            python-version: '3.11'
 
       - name: Get tag
         id: tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v7
       - run: |

--- a/.github/workflows/manual-build-docs-version.yml
+++ b/.github/workflows/manual-build-docs-version.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-            python-version: '3.10'
+            python-version: '3.11'
 
       - name: Install docs requirements
         run: pip install -r docs/requirements.txt

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -28,4 +28,4 @@ pip install gymnasium-robotics[mujoco-py-original]
 
 
 
-We support and test for Python 3.10, 3.11, 3.12 and 3.13 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support and test for Python 3.11, 3.12 and 3.13 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "gymnasium-robotics"
 description = "RL Robotics environments with Gymnasium API."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "Gymnasium", "RL", "AI", "Robotics"]
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -87,7 +86,7 @@ exclude = [
 strict = []
 
 typeCheckingMode = "basic"
-pythonVersion = "3.10"
+pythonVersion = "3.11"
 pythonPlatform = "All"
 typeshedPath = "typeshed"
 enableTypeIgnoreComments = true


### PR DESCRIPTION
Drop Python 3.10 support for the next release by requiring Python >=3.11. Remove 3.10 from package classifiers and the test matrix, set Pyright and all documentation workflows to 3.11, and update the installation documentation.

Closes #328.

Validation: generated wheel metadata rejects Python 3.10 and accepts 3.11–3.13; all repository pre-commit checks pass. No runtime code changes.
