### PR TITLE
Fix stale PointMaze goal after target reset

### DIFF
--- a/gymnasium_robotics/envs/maze/point_maze.py
+++ b/gymnasium_robotics/envs/maze/point_maze.py
@@ -392,16 +392,24 @@ class PointMazeEnv(MazeEnv, EzPickle):
     def step(self, action):
         obs, _, _, _, info = self.point_env.step(action)
         obs_dict = self._get_obs(obs)
+        # Transition signals use the goal that was active while the action executed.
+        transition_goal = obs_dict["desired_goal"]
 
-        reward = self.compute_reward(obs_dict["achieved_goal"], self.goal, info)
-        terminated = self.compute_terminated(obs_dict["achieved_goal"], self.goal, info)
-        truncated = self.compute_truncated(obs_dict["achieved_goal"], self.goal, info)
+        reward = self.compute_reward(obs_dict["achieved_goal"], transition_goal, info)
+        terminated = self.compute_terminated(
+            obs_dict["achieved_goal"], transition_goal, info
+        )
+        truncated = self.compute_truncated(
+            obs_dict["achieved_goal"], transition_goal, info
+        )
         info["success"] = bool(
-            np.linalg.norm(obs_dict["achieved_goal"] - self.goal) <= 0.45
+            np.linalg.norm(obs_dict["achieved_goal"] - transition_goal) <= 0.45
         )
 
         # Update the goal position if necessary
         self.update_goal(obs_dict["achieved_goal"])
+        # Returned desired_goal is the goal for the next policy step.
+        obs_dict["desired_goal"] = self.goal.copy()
 
         return obs_dict, reward, terminated, truncated, info
 

--- a/tests/envs/maze/test_point_maze.py
+++ b/tests/envs/maze/test_point_maze.py
@@ -43,3 +43,77 @@ def test_goal_cell():
     obs = env.reset(options={"goal_cell": [2, 1]}, seed=42)[0]
     desired_goal = np.array([-0.36302198, -0.53056078])
     np.testing.assert_almost_equal(desired_goal, obs["desired_goal"], decimal=4)
+
+
+def test_step_returns_updated_goal_after_goal_reset():
+    """After reaching the goal in a continuing task, step should return the new desired_goal.
+
+    Regression for Issue #258: with continuing_task=True and reset_target=True, update_goal
+    changes the internal goal after success, but the returned observation currently still
+    contains the old desired_goal. The next policy call must see the updated goal.
+    """
+    maze_map = [
+        [1, 1, 1, 1, 1],
+        [1, "r", "g", "g", 1],
+        [1, 1, 1, 1, 1],
+    ]
+    # position_noise_range cannot be passed through gym.make: PointMazeEnv forwards
+    # unused kwargs into PointEnv/MujocoEnv, which rejects this MazeEnv-only argument.
+    env = gym.make(
+        "PointMaze_UMaze-v3",
+        maze_map=maze_map,
+        continuing_task=True,
+        reset_target=True,
+        reward_type="sparse",
+        max_episode_steps=100,
+    )
+    try:
+        env.unwrapped.position_noise_range = 0.0
+        obs, _ = env.reset(
+            seed=0,
+            options={
+                "reset_cell": np.array([1, 1]),
+                "goal_cell": np.array([1, 2]),
+            },
+        )
+        old_goal = obs["desired_goal"].copy()
+
+        # Public API cannot teleport onto the goal without an expert policy or long
+        # random rollouts; set MuJoCo state so the next step reliably triggers success.
+        point_env = env.unwrapped.point_env
+        point_env.set_state(
+            np.concatenate([old_goal, point_env.data.qpos[2:]]),
+            np.zeros_like(point_env.data.qvel),
+        )
+
+        obs, reward, terminated, truncated, info = env.step(
+            np.zeros(env.action_space.shape, dtype=np.float32)
+        )
+        new_goal = env.unwrapped.goal.copy()
+        returned_desired_goal = obs["desired_goal"]
+
+        assert info["success"] is True
+        assert reward == 1.0
+        assert terminated is False
+        assert truncated is False
+        assert not np.allclose(old_goal, new_goal), (
+            "Expected update_goal to switch the internal goal after success, "
+            f"but old_goal={old_goal} new_goal={new_goal}"
+        )
+        np.testing.assert_allclose(
+            returned_desired_goal,
+            new_goal,
+            err_msg=(
+                "Returned desired_goal should match the post-step internal goal so the "
+                "next policy call tracks the new target. "
+                f"old_goal={old_goal}, returned_desired_goal={returned_desired_goal}, "
+                f"internal_goal={new_goal}"
+            ),
+        )
+        assert not np.allclose(returned_desired_goal, old_goal), (
+            "Returned desired_goal should not remain the pre-switch goal. "
+            f"old_goal={old_goal}, returned_desired_goal={returned_desired_goal}, "
+            f"internal_goal={new_goal}"
+        )
+    finally:
+        env.close()


### PR DESCRIPTION
When PointMaze reaches a target with `continuing_task=True` and `reset_target=True`, it updates its internal goal after constructing the observation, leaving the returned `desired_goal` stale. This draft keeps the transition signals tied to the goal active during the action, then updates the returned observation to contain the next target. It includes the original deterministic regression test.

Restores the proposal from #319, originally authored by @Strtus. GitHub refused to reopen that PR, whose source repository is no longer available. This draft retains its original commits and authorship without modifying the implementation. See #319 for the original discussion and validation reports.

Refs #258.

## Open semantic decision

On a target-switch transition, the returned observation contains the next target while the reward belongs to the target just reached. Recomputing the reward with the returned `observation["desired_goal"]` therefore produces a different value.

The proposal leaves this interface decision open: whether to retain the previous target in `info`, use a different transition convention, and introduce a new Maze environment version. It does not add an `info` field or change `compute_reward`. AntMaze has the same ordering, but this implementation and its regression test cover PointMaze only.

## Validation

Verified that the restored head is the exact head of #319 (`d2830c9329e1bb51c92da8ccb8de34607b9d8b4e`) and that its diff against current `main` contains only `gymnasium_robotics/envs/maze/point_maze.py` and `tests/envs/maze/test_point_maze.py`.

Tests have not been rerun for this restoration. The original author reported passing pre-commit checks, 4 PointMaze tests, 8 Maze tests, and 100 PointMaze-selected environment tests in #319, with full-suite collection blocked by a missing legacy MuJoCo installation on Windows.
