### PR TITLE
Require MuJoCo 2.2.2 for mocap weld resets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
 ]
 dependencies = [
-    "mujoco>=2.2.0",
+    "mujoco>=2.2.2",
     "numpy>=1.21.0",
     "gymnasium>=1.2.0",
     "PettingZoo>=1.23.0",


### PR DESCRIPTION
The mocap weld reset fixed in #333 uses MuJoCo's 11-value equality layout, introduced in 2.2.2. The package still allows 2.2.0 and 2.2.1, where the shorter arrays cause a broadcasting error during initialization. Raise the minimum dependency to `mujoco>=2.2.2` to exclude those versions.

Validation: built the wheel and verified its `Requires-Dist` metadata excludes 2.2.0 and 2.2.1 and accepts 2.2.2 and 3.12.0. `git diff --check` passes.
